### PR TITLE
Front end update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'archive-zip', '~> 0.9.0'
 gem 'airbrake', '~> 7.2'
 gem 'deep_cloneable', '~> 2.3.0'
 
-gem 'transformer', ref: '119b910', github: 'quintel/transformer'
+gem 'transformer', ref: 'd786506', github: 'quintel/transformer'
 gem 'atlas',       ref: '8583424', github: 'quintel/atlas'
 gem 'rubel',       ref: 'ad3d44e', github: 'quintel/rubel'
 gem 'refinery',    ref: '636686c', github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/transformer.git
-  revision: 119b91065b4881e16efde1a515898cdd49979560
-  ref: 119b910
+  revision: d7865067bd6b5b2480a077aed97cf56422232737
+  ref: d786506
   specs:
     transformer (1.0.0)
       atlas (~> 1.0)

--- a/app/assets/javascripts/dataset_interface/change_trigger.js
+++ b/app/assets/javascripts/dataset_interface/change_trigger.js
@@ -1,10 +1,11 @@
 DatasetInterface.ChangeTrigger = {
     trigger: function (attribute) {
         var showChanges;
+        var attributeEl = $(attribute);
 
-        $(attribute).toggleClass("changed", $(attribute).val() !== '');
+        attributeEl.toggleClass("changed", attributeEl.val() !== '');
 
-        showChanges = $('input.changed, div.slider.changed').length > 0;
+        showChanges = $('input.changed').length > 0;
 
         $('input.changed').removeClass('valid invalid');
 

--- a/app/assets/javascripts/sliders/slider.js
+++ b/app/assets/javascripts/sliders/slider.js
@@ -14,11 +14,11 @@ var Slider = (function () {
         this.spanVal.text(Math.round(value * 100) / 100);
     }
 
-    // Callback for dragging the slider
-    function drag(value) {
+    // Callback for changing the slider
+    function change(value) {
         setValue.call(this, value);
 
-        DatasetInterface.ChangeTrigger.trigger(this.sliderEl);
+        DatasetInterface.ChangeTrigger.trigger(this.input);
     }
 
     function showInput() {
@@ -62,7 +62,8 @@ var Slider = (function () {
                 value:   this.input.val() * 100,
                 step:    1,
                 setup:   setVal.bind(this),
-                drag:    drag.bind(this),
+                drag:    setVal.bind(this),
+                change:  change.bind(this),
                 max:     100,
                 disable: true
             });
@@ -97,7 +98,7 @@ var Slider = (function () {
                 // when setting the defaults).
                 this.slider.setTentativeValue(value * 100.0, true, true);
 
-                setVal.call(this, value * 100.0);
+                setValue.call(this, value * 100.0);
             }
         }
     };

--- a/app/assets/javascripts/sliders/slider.js
+++ b/app/assets/javascripts/sliders/slider.js
@@ -96,7 +96,7 @@ var Slider = (function () {
                 // Oddly specific: the last argument is a silent call so
                 // no changes are being triggered (which is what we want
                 // when setting the defaults).
-                this.slider.setTentativeValue(value * 100.0, true, true);
+                this.slider.setTentativeValue(value * 100.0, false, true);
 
                 setValue.call(this, value * 100.0);
             }

--- a/app/assets/javascripts/sliders/slider_group.js
+++ b/app/assets/javascripts/sliders/slider_group.js
@@ -9,9 +9,17 @@ var SliderGroup = (function () {
                 return new Slider(scope);
             });
 
-            this.sliders.forEach(function (slider) {
-                this.balancer.add(slider.create());
-            }.bind(this));
+            if (this.sliders.length < 2) {
+                this.sliders.forEach(function (slider) {
+                    slider.create();
+                });
+            } else {
+                this.sliders.forEach(function (slider) {
+                    this.balancer.add(slider.create());
+                }.bind(this));
+
+                this.setFlexSlider();
+            }
         },
 
         setFlexSlider: function () {

--- a/app/assets/javascripts/sliders/slider_group.js
+++ b/app/assets/javascripts/sliders/slider_group.js
@@ -3,23 +3,27 @@ var SliderGroup = (function () {
 
     SliderGroup.prototype = {
         render: function () {
-            this.balancer = new $.Quinn.Balancer();
+            var controls;
+            var balancer;
 
             this.sliders = $.map($(this.scope).find('.editable.slider'), function (scope) {
                 return new Slider(scope);
             });
 
-            if (this.sliders.length < 2) {
-                this.sliders.forEach(function (slider) {
-                    slider.create();
-                });
-            } else {
-                this.sliders.forEach(function (slider) {
-                    this.balancer.add(slider.create());
-                }.bind(this));
+            controls = this.sliders.map(function(slider) {
+                return slider.create();
+            });
 
+            if (this.isFlexGroup()) {
+                balancer = new $.Quinn.Balancer();
+                controls.forEach(balancer.add.bind(balancer));
                 this.setFlexSlider();
             }
+        },
+
+        isFlexGroup: function() {
+            return this.sliders.length > 1 &&
+                this.sliders.some(function(slider) { return slider.flexible });
         },
 
         setFlexSlider: function () {

--- a/app/assets/javascripts/sliders/slider_group_collection.js
+++ b/app/assets/javascripts/sliders/slider_group_collection.js
@@ -12,7 +12,6 @@ var SliderGroupCollection = (function () {
             if (sliderGroups.length > 0) {
                 sliderGroups.forEach(function (sliderGroup) {
                     sliderGroup.render();
-                    sliderGroup.setFlexSlider();
                 }.bind(this));
             }
         }

--- a/app/models/etsource.rb
+++ b/app/models/etsource.rb
@@ -1,5 +1,7 @@
 module Etsource
-  def self.datasets
+  module_function
+
+  def datasets
     @datasets ||= Hash[Atlas::Dataset::Derived.all.map do |dataset|
       [dataset.geo_id, dataset]
     end]
@@ -7,13 +9,24 @@ module Etsource
 
   # Returns all dataset input keys from sparse graph queries
   # Used to check if an interface element is still required.
-  def self.dataset_inputs
+  def dataset_inputs
     @dataset_inputs ||= Atlas::SparseGraphQuery.all.flat_map do |query|
       query.query.scan(/DATASET_INPUT\(['"]?([a-z0-9_]+)['"]?\)/).flatten
     end
   end
 
-  def self.transformers
+  def transformers
     @transformers ||= Transformer::GraphMethods.all
+  end
+
+  # Public: A set of symbols containing all the transformer keys an dataset
+  # attributes whose values may be set by users.
+  #
+  # Returns a Set.
+  def whitelisted_attributes
+    @whitelisted_attributes ||= Set.new(
+      transformers.keys +
+        Transformer::DatasetCast.attribute_set.map(&:name)
+    ).freeze
   end
 end

--- a/app/models/interface_element.rb
+++ b/app/models/interface_element.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InterfaceItem
   include Virtus.model
   include ActiveModel::Validations
@@ -13,7 +15,8 @@ class InterfaceItem
   attribute :hidden, Boolean, default: false
 
   def whitelisted?
-    Etsource.transformers.keys.include?(key) || key =~ /^input/
+    Etsource.whitelisted_attributes.include?(key) ||
+      key.to_s.start_with?('input_')
   end
 end
 

--- a/config/interface_elements/area/area_advanced.yml
+++ b/config/interface_elements/area/area_advanced.yml
@@ -29,6 +29,7 @@ groups:
         unit: '€'
 
   - header: area_electricity_grid_capacity
+    type: slider
     items:
       - key: lv_net_spare_capacity
         unit: '%'

--- a/config/interface_elements/buildings/buildings_energy_demand.yml
+++ b/config/interface_elements/buildings/buildings_energy_demand.yml
@@ -1,6 +1,7 @@
 key: buildings_energy_demand
 groups:
-  - items:
+  - header: buildings_final_demand
+    items:
     - key: input_buildings_electricity_demand
       unit: 'TJ'
     - key: buildings_final_demand_network_gas_demand

--- a/config/interface_elements/buildings/buildings_energy_supply.yml
+++ b/config/interface_elements/buildings/buildings_energy_supply.yml
@@ -4,8 +4,6 @@ groups:
     items:
       - key: input_buildings_solar_pv_demand
         unit: 'TJ'
-      - key: input_buildings_solar_pv_own_use_share
-        unit: '%'
       - key: buildings_final_demand_solar_thermal_demand
         unit: 'TJ'
 

--- a/config/interface_elements/energy/energy.yml
+++ b/config/interface_elements/energy/energy.yml
@@ -4,6 +4,8 @@ groups:
     items:
       - key: energy_power_sector_own_use_electricity_demand
         unit: 'TJ'
+      - key: energy_power_hv_network_loss_demand
+        unit: 'TJ'
 
   - header: energy_greengas
     items:

--- a/config/interface_elements/households/households.yml
+++ b/config/interface_elements/households/households.yml
@@ -1,9 +1,18 @@
 key: households
 groups:
-  - items:
+  - header:
+    items:
     - key: number_of_residences
       unit: '#'
-    - key: input_percentage_of_old_residences
-      unit: '%'
     - key: residences_roof_surface_available_for_pv
       unit: 'km<sup>2</sup>'
+
+  - header:
+    type: slider
+    items:
+    - key: input_percentage_of_old_residences
+      unit: '%'
+    - key: input_percentage_of_new_residences
+      unit: '%'
+      flexible: true
+      skip_validation: true

--- a/config/interface_elements/households/households_energy_demand.yml
+++ b/config/interface_elements/households/households_energy_demand.yml
@@ -1,7 +1,8 @@
 key: households_energy_demand
 groups:
-  - items:
-    - key: input_households_electricity_demand
+  - header: households_final_demand
+    items:
+    - key: households_final_demand_electricity_demand
       unit: 'TJ'
     - key: households_final_demand_network_gas_demand
       unit: 'TJ'

--- a/config/interface_elements/households/households_energy_supply.yml
+++ b/config/interface_elements/households/households_energy_supply.yml
@@ -4,8 +4,6 @@ groups:
     items:
       - key: input_households_solar_pv_demand
         unit: 'TJ'
-      - key: input_households_solar_pv_own_use_share
-        unit: '%'
       - key: households_final_demand_solar_thermal_demand
         unit: 'TJ'
 

--- a/config/interface_elements/industry/industry.yml
+++ b/config/interface_elements/industry/industry.yml
@@ -1,5 +1,4 @@
 key: industry
-
 groups:
   - header: industry_chps
     items:
@@ -11,3 +10,14 @@ groups:
         unit: 'TJ'
       - key: industry_chp_ultra_supercritical_coal_demand
         unit: 'TJ'
+
+  - header: industry_gas_fuelmix
+    type: slider
+    items:
+      - key: input_share_mixer_gas_fuel_bio_oil
+        unit: '%'
+      - key: input_share_mixer_gas_fuel_oil
+        unit: '%'
+      - key: input_share_mixer_gas_fuel_network_gas
+        unit: '%'
+        flexible: true

--- a/config/interface_elements/industry/industry_chemical.yml
+++ b/config/interface_elements/industry/industry_chemical.yml
@@ -2,13 +2,17 @@ key: industry_chemical
 
 groups:
   - header: industry_chemical_fertilizers
+    type: slider
     items:
-      - key: input_industry_chemical_fertilizers_scaling_factor
-        unit: '%'
+    - key: input_industry_chemical_fertilizers_scaling_factor
+      unit: '%'
+
   - header: industry_chemical_refineries
+    type: slider
     items:
-      - key: input_industry_chemical_refineries_scaling_factor
-        unit: '%'
+    - key: input_industry_chemical_refineries_scaling_factor
+      unit: '%'
+
   - header: industry_chemical_other
     items:
       - key: input_industry_chemical_other_electricity_demand

--- a/config/interface_elements/industry/industry_metal.yml
+++ b/config/interface_elements/industry/industry_metal.yml
@@ -2,13 +2,17 @@ key: industry_metal
 
 groups:
   - header: industry_metal_steel
+    type: slider
     items:
       - key: input_industry_metal_steel_scaling_factor
         unit: '%'
+
   - header: industry_metal_aluminium
+    type: slider
     items:
       - key: input_industry_metal_aluminium_scaling_factor
         unit: '%'
+
   - header: industry_metal_other
     items:
       - key: input_industry_metal_other_electricity_demand

--- a/config/locales/en_attributes.yml
+++ b/config/locales/en_attributes.yml
@@ -42,18 +42,18 @@ en:
 
         #households
         number_of_residences: Number of residences
-        input_percentage_of_old_residences: Percentage of residences built before 1992
+        input_percentage_of_old_residences: Residences built before 1992
+        input_percentage_of_new_residences: Residences built in or after 1992
         residences_roof_surface_available_for_pv: Roof surface suitable for solar PV
 
-        input_households_electricity_demand: Electricity demand
-        households_final_demand_network_gas_demand: Gas demand
-        households_final_demand_steam_hot_water_demand: Heat demand
-        households_final_demand_wood_pellets_demand: Biomass demand
-        households_final_demand_crude_oil_demand: Oil demand
-        households_final_demand_coal_demand: Coal demand
+        households_final_demand_electricity_demand: Electricity
+        households_final_demand_network_gas_demand: Gas
+        households_final_demand_steam_hot_water_demand: Heat
+        households_final_demand_wood_pellets_demand: Biomass
+        households_final_demand_crude_oil_demand: Oil
+        households_final_demand_coal_demand: Coal
 
         input_households_solar_pv_demand: Solar PV production
-        input_households_solar_pv_own_use_share: Own use solar PV production
         households_final_demand_solar_thermal_demand: Solar thermal production
         input_households_district_heating_heater_network_gas_share: Gas heater
         input_households_district_heating_chp_network_gas_share: Gas CHP
@@ -148,7 +148,6 @@ en:
         buildings_final_demand_crude_oil_demand: Oil demand
 
         input_buildings_solar_pv_demand: Solar PV production
-        input_buildings_solar_pv_own_use_share: Own use solar PV production
         buildings_final_demand_solar_thermal_demand: Solar thermal production
         input_buildings_district_heating_heater_network_gas_share: Gas heater
         input_buildings_district_heating_chp_network_gas_share: Gas CHP
@@ -276,8 +275,12 @@ en:
         industry_chp_turbine_gas_power_fuelmix_demand: Gas turbine CHP
         industry_chp_ultra_supercritical_coal_demand: Coal CHP
 
-        input_industry_metal_steel_scaling_factor: Percentage of national steel industry
-        input_industry_metal_aluminium_scaling_factor: Percentage of national aluminium industry
+        input_share_mixer_gas_fuel_network_gas: Gas
+        input_share_mixer_gas_fuel_oil: Oil
+        input_share_mixer_gas_fuel_bio_oil: Bio oil
+
+        input_industry_metal_steel_scaling_factor: "% national steel industry"
+        input_industry_metal_aluminium_scaling_factor: "% national aluminium industry"
         input_industry_metal_other_electricity_demand: Electricity
         input_industry_metal_other_network_gas_demand: Gas
         input_industry_metal_other_steam_hot_water_demand: Heat
@@ -285,8 +288,8 @@ en:
         input_industry_metal_other_crude_oil_demand: Oil
         input_industry_metal_other_coal_demand: Coal
 
-        input_industry_chemical_fertilizers_scaling_factor: Percentage of national fertilizer industry
-        input_industry_chemical_refineries_scaling_factor: Percentage of national refinery industry
+        input_industry_chemical_fertilizers_scaling_factor: "% national fertilizer industry"
+        input_industry_chemical_refineries_scaling_factor: "% national refinery industry"
         input_industry_chemical_other_electricity_demand: Electricity
         input_industry_chemical_other_network_gas_demand: Gas
         input_industry_chemical_other_steam_hot_water_demand: Heat
@@ -329,7 +332,8 @@ en:
         input_industry_other_coal_non_energetic_demand: Coal (non-energetic)
 
         # Energy
-        energy_power_sector_own_use_electricity_demand: Electricity
+        energy_power_sector_own_use_electricity_demand: Own use of electricity
+        energy_power_hv_network_loss_demand: Network losses
         input_energy_greengas_production: Local greengas production
         energy_import_greengas_demand: Import of greengas
 

--- a/config/locales/en_dataset_edits.yml
+++ b/config/locales/en_dataset_edits.yml
@@ -20,7 +20,7 @@ en:
       #area
       area_other_ghg: "Present non-CO<sub>2</sub> greenhouse gas emissions"
       area_electricity_grid_costs: Present electricity grid costs
-      area_electricity_grid_capacity: Present electricity grid capacity
+      area_electricity_grid_capacity: Present spare capacity electricity grid
       area_electricity_grid_reinforcement: Electricity grid reinforcement
 
       #households

--- a/config/locales/en_dataset_edits.yml
+++ b/config/locales/en_dataset_edits.yml
@@ -24,6 +24,7 @@ en:
       area_electricity_grid_reinforcement: Electricity grid reinforcement
 
       #households
+      households_final_demand: Final demand
       households_local_production: Local energy production
       households_district_heating: District heating
       households_electricity_distribution: Electricity distribution
@@ -43,6 +44,7 @@ en:
       households_solar_thermal_distribution: Solar thermal distribution
 
       #buildings
+      buildings_final_demand: Final demand
       buildings_local_production: Local energy production
       buildings_district_heating: District heating
       buildings_electricity_distribution: Electricity distribution
@@ -76,6 +78,7 @@ en:
 
       # industry
       industry_chps: CHPs
+      industry_gas_fuelmix: Fuel for gas-fired CHPs
       industry_metal_steel: Steel
       industry_metal_aluminium: Aluminium
       industry_metal_other: Other metal industry

--- a/config/locales/en_datasets.yml
+++ b/config/locales/en_datasets.yml
@@ -58,9 +58,9 @@ en:
         buildings_final_demand_crude_oil: Crude oil
 
       energy:
-        energy_heat_production: Heat production
-        energy_fossil_electricity_production: Fossil electricity production
-        energy_renewable_electricity_production: Renewable electricity production
+        energy_heat_production: Heat
+        energy_fossil_electricity_production: Fossil electricity
+        energy_renewable_electricity_production: Renewable electricity
 
       households:
         households_advanced: Advanced

--- a/config/locales/nl_attributes.yml
+++ b/config/locales/nl_attributes.yml
@@ -43,18 +43,18 @@ nl:
 
         #households
         number_of_residences: Aantal woningen
-        input_percentage_of_old_residences: Percentage woningen gebouwd voor 1992
+        input_percentage_of_old_residences: Woningen gebouwd voor 1992
+        input_percentage_of_new_residences: Woningen gebouwd in of na 1992
         residences_roof_surface_available_for_pv: Geschikt dakoppervlak voor zon-PV
 
-        input_households_electricity_demand: Elektriciteitsgebruik
-        households_final_demand_network_gas_demand: Gasgebruik
-        households_final_demand_steam_hot_water_demand: Warmtegebruik
-        households_final_demand_wood_pellets_demand: Biomassagebruik
-        households_final_demand_crude_oil_demand: Oliegebruik
-        households_final_demand_coal_demand: Kolengebruik
+        households_final_demand_electricity_demand: Elektriciteit
+        households_final_demand_network_gas_demand: Gas
+        households_final_demand_steam_hot_water_demand: Warmte
+        households_final_demand_wood_pellets_demand: Biomassa
+        households_final_demand_crude_oil_demand: Olie
+        households_final_demand_coal_demand: Kolen
 
         input_households_solar_pv_demand: Zon-PV-productie
-        input_households_solar_pv_own_use_share: Eigen gebruik zon-PV-productie
         households_final_demand_solar_thermal_demand: Zonthermieproductie
         input_households_district_heating_heater_network_gas_share: Gasketel
         input_households_district_heating_chp_network_gas_share: Gas-WKK
@@ -149,7 +149,6 @@ nl:
         buildings_final_demand_crude_oil_demand: Oliegebruik
 
         input_buildings_solar_pv_demand: Zon-PV-productie
-        input_buildings_solar_pv_own_use_share: Eigen gebruik zon-PV-productie
         buildings_final_demand_solar_thermal_demand: Zonthermieproductie
         input_buildings_district_heating_heater_network_gas_share: Gasketel
         input_buildings_district_heating_chp_network_gas_share: Gas-WKK
@@ -277,8 +276,12 @@ nl:
         industry_chp_turbine_gas_power_fuelmix_demand: Gasturbine-WKK
         industry_chp_ultra_supercritical_coal_demand: Kolen-WKK
 
-        input_industry_metal_steel_scaling_factor: Percentage van de nationale staalindustrie
-        input_industry_metal_aluminium_scaling_factor: Percentage van de nationale aluminiumindustrie
+        input_share_mixer_gas_fuel_network_gas: Gas
+        input_share_mixer_gas_fuel_oil: Olie
+        input_share_mixer_gas_fuel_bio_oil: Bio-olie
+
+        input_industry_metal_steel_scaling_factor: "% nationale staalsector"
+        input_industry_metal_aluminium_scaling_factor: "% nationale aluminiumsector"
         input_industry_metal_other_electricity_demand: Elektriciteit
         input_industry_metal_other_network_gas_demand: Gas
         input_industry_metal_other_steam_hot_water_demand: Warmte
@@ -286,8 +289,8 @@ nl:
         input_industry_metal_other_crude_oil_demand: Olie
         input_industry_metal_other_coal_demand: Kolen
 
-        input_industry_chemical_fertilizers_scaling_factor: Percentage van de nationale kunstmestsector
-        input_industry_chemical_refineries_scaling_factor: Percentage van de nationale raffinaderijensector
+        input_industry_chemical_fertilizers_scaling_factor: "% nationale kunstmestsector"
+        input_industry_chemical_refineries_scaling_factor: "% nationale raffinaderijensector"
         input_industry_chemical_other_electricity_demand: Elektriciteit
         input_industry_chemical_other_network_gas_demand: Gas
         input_industry_chemical_other_steam_hot_water_demand: Warmte
@@ -330,7 +333,8 @@ nl:
         input_industry_other_coal_non_energetic_demand: Kolen (niet-energetisch)
 
         # Energy
-        energy_power_sector_own_use_electricity_demand: Elektriciteit
+        energy_power_sector_own_use_electricity_demand: Eigen gebruik elektriciteit
+        energy_power_hv_network_loss_demand: Netverliezen
         input_energy_greengas_production: Lokale groengasproductie
         energy_import_greengas_demand: Import van groengas
 

--- a/config/locales/nl_dataset_edits.yml
+++ b/config/locales/nl_dataset_edits.yml
@@ -24,8 +24,8 @@ nl:
       #area
       area_other_ghg: "Huidige uitstoot niet-CO<sub>2</sub>-broeikasgassen"
       area_electricity_grid_costs: Kosten elektriciteitsnetwerk
-      area_electricity_grid_capacity: Capaciteit elektriciteitsnetwerk
-      area_electricity_grid_reinforcement: Verzwaring elektriciteitsnetwerk
+      area_electricity_grid_capacity: Beschikbare capaciteit huidig elektriciteitsnet
+      area_electricity_grid_reinforcement: Verzwaring elektriciteitsnet
 
       #households
       households_final_demand: Eindgebruik

--- a/config/locales/nl_dataset_edits.yml
+++ b/config/locales/nl_dataset_edits.yml
@@ -28,6 +28,7 @@ nl:
       area_electricity_grid_reinforcement: Verzwaring elektriciteitsnetwerk
 
       #households
+      households_final_demand: Eindgebruik
       households_local_production: Lokale energieproductie
       households_district_heating: Warmtenet
       households_electricity_distribution: Verdeling elektriciteit
@@ -47,6 +48,7 @@ nl:
       households_solar_thermal_distribution: Verdeling zonthermie
 
       #buildings
+      buildings_final_demand: Final demand
       buildings_local_production: Lokale energieproductie
       buildings_district_heating: Warmtenet
       buildings_electricity_distribution: Verdeling elektriciteit
@@ -80,6 +82,7 @@ nl:
 
       # industry
       industry_chps: WKK's
+      industry_gas_fuelmix: Brandstofmix gasgestookte WKK
       industry_metal_steel: Staal
       industry_metal_aluminium: Aluminium
       industry_metal_other: Overige metaalindustrie

--- a/config/locales/nl_datasets.yml
+++ b/config/locales/nl_datasets.yml
@@ -58,9 +58,9 @@ nl:
         buildings_final_demand_crude_oil: Olie
 
       energy:
-        energy_heat_production: Warmteproductie
-        energy_fossil_electricity_production: Fossiele elektriciteitsopwek
-        energy_renewable_electricity_production: Duurzame elektriciteitsopwek
+        energy_heat_production: Warmte
+        energy_fossil_electricity_production: Fossiele elektriciteit
+        energy_renewable_electricity_production: Duurzame elektriciteit
 
       households:
         households_energy_demand: Energievraag

--- a/spec/models/editable_attributes_collection_spec.rb
+++ b/spec/models/editable_attributes_collection_spec.rb
@@ -23,7 +23,7 @@ describe EditableAttributesCollection do
   it 'expands on the graph methods' do
     expect(
       editable_attributes
-        .find('input_households_electricity_demand')
+        .find('input_industry_paper_electricity_demand')
     ).to be_a(EditableAttribute)
   end
 
@@ -37,6 +37,6 @@ describe EditableAttributesCollection do
 
   it 'does not have a default value for electricity_consumption' do
     expect(editable_attributes
-      .find('input_households_electricity_demand').value).to eq(nil)
+      .find('input_industry_paper_electricity_demand').value).to eq(nil)
   end
 end


### PR DESCRIPTION
Updated the front-end:
- Changed all input fields with unit '%' to proper sliders. This should fix: https://github.com/quintel/etlocal/issues/118
- Added/removed keys and sparse graph queries to fix Semaphore errors (goes with https://github.com/quintel/etsource/pull/1769)
- Simplified front-end by removing ``input_buildings_solar_pv_own_use_share``, ``input_households_solar_pv_own_use_share``.

When testing this locally, some sliders don't show up properly (see screenshots). Can you have a quick look whether this happens on your machine as well @antw? Not sure if related, by in my browser console I get quite some errors like ``tile does not exist`` from mapbox.com.


Sliders not showing up or cannot 'slide' them (tab Industry -> Metal and Industry -> Chemical):
![etlocal httplocalhost3000 2018-07-02 09-37-19](https://user-images.githubusercontent.com/32056448/42151678-0d755352-7dde-11e8-9e19-ff489d76b1e4.png)

Sliders showing up but cannot 'slide' them (Industry general tab):
![etlocal httplocalhost3000 2018-07-02 09-37-37](https://user-images.githubusercontent.com/32056448/42151706-2241d49a-7dde-11e8-9883-dad095b5d6d6.png)

Errors in console:
![etlocal httplocalhost3000 2018-07-02 09-57-57](https://user-images.githubusercontent.com/32056448/42151815-7150dc48-7dde-11e8-9004-210a66777a15.png)


