### PR TITLE
Remove all robot datases with zero commits

### DIFF
--- a/db/migrate/20181029145343_remove_empty_datasets.rb
+++ b/db/migrate/20181029145343_remove_empty_datasets.rb
@@ -1,0 +1,16 @@
+class RemoveEmptyDatasets < ActiveRecord::Migration[5.0]
+  def up
+    raise 'Could not find Robot user' unless User.robot
+
+    execute <<~SQL
+      DELETE FROM datasets
+      WHERE
+        user_id = #{User.robot.id} AND
+        id NOT IN (SELECT dataset_id FROM commits)
+    SQL
+  end
+
+  def down
+    ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181026144724) do
+ActiveRecord::Schema.define(version: 20181029145343) do
 
   create_table "commits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "source_id"


### PR DESCRIPTION
Removes the old datasets whose commits and datasets edits were removed when the DB was reseeded. Datasets with one or more commits, or belonging to anyone other than the Robot, are left untouched.