### PR TITLE
dataset exporter: replace special characters

### DIFF
--- a/app/controllers/api/v1/exports_controller.rb
+++ b/app/controllers/api/v1/exports_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::ExportsController < ApplicationController
 
     json = datasets.map do |dataset|
       dataset.editable_attributes.as_json.merge(
-        area: "#{dataset.geo_id}_#{dataset.name.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/n,'').delete('().\'').gsub(' ', '_').downcase.to_s}",
+        area: "#{dataset.geo_id}_#{dataset.normalized_name}",
         base_dataset: dataset.country,
         group: dataset.group
       )

--- a/app/controllers/api/v1/exports_controller.rb
+++ b/app/controllers/api/v1/exports_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::ExportsController < ApplicationController
 
     json = datasets.map do |dataset|
       dataset.editable_attributes.as_json.merge(
-        area: "#{dataset.geo_id}_#{dataset.name.downcase.tr(' ', '_')}",
+        area: "#{dataset.geo_id}_#{dataset.name.mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/n,'').delete('().\'').gsub(' ', '_').downcase.to_s}",
         base_dataset: dataset.country,
         group: dataset.group
       )

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -53,12 +53,17 @@ class Dataset < ApplicationRecord
     @editable_attributes ||= EditableAttributesCollection.new(self)
   end
 
-  def temp_name
-    @temp_name ||= begin
-      stripped = name.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+  # Public: A version of the dataset name with normalize unicode characters, and
+  # any non-alphanumeric characters removed.
+  #
+  # Returns a string.
+  def normalized_name
+    name.strip.mb_chars.normalize(:kd).to_s
+      .downcase.gsub(/[^0-9a-z_\s\-]/, '').gsub(/[\s_-]+/, '_')
+  end
 
-      "#{ SecureRandom.hex(10) }-#{ stripped }"
-    end
+  def temp_name
+    @temp_name ||= "#{SecureRandom.hex(10)}-#{normalized_name}"
   end
 
   def creator

--- a/spec/controllers/api/v1/exports_controller_spec.rb
+++ b/spec/controllers/api/v1/exports_controller_spec.rb
@@ -38,4 +38,16 @@ describe Api::V1::ExportsController do
       expect(body.fetch('number_of_cars')).to eq(2.0)
     end
   end
+
+  describe 'with special characters in the dataset name' do
+    let(:dataset) do
+      FactoryGirl.create(:dataset, name: "háp-py\n∑®'&^-%_().  o… ")
+    end
+
+    it 'removes special characters' do
+      get :show, params: { id: dataset.id }, format: :json
+
+      expect(body['area']).to eq('ameland_hap_py_o')
+    end
+  end
 end


### PR DESCRIPTION
ETModel doesn't display datasets in the dataset selector and/or open a dataset if the dataset name contains special characters (like ``(`` or ``.``). 

I modified the dataset exporter to ensure that datasets exported to ETSource do not contain these characters:
- replaces accented characters with non-accented characters
- replaces spaces with underscores
- removes dots, parentheses, inverted commas

Tested with the Groningen datasets and it seems to work fine.

Priority is low.