### PR TITLE
Fix incorrect initial building lighting shares

### DIFF
--- a/db/migrate/20181218173807_fix_incorrect_building_lighting_shares.rb
+++ b/db/migrate/20181218173807_fix_incorrect_building_lighting_shares.rb
@@ -1,0 +1,38 @@
+class FixIncorrectBuildingLightingShares < ActiveRecord::Migration[5.0]
+  CHANGES = {
+    buildings_final_demand_for_lighting_electricity_buildings_lighting_standard_fluorescent_electricity_parent_share: [0.05, 0.94],
+    buildings_final_demand_for_lighting_electricity_buildings_lighting_efficient_fluorescent_electricity_parent_share: [0.94, 0.05]
+  }.freeze
+
+  def up
+    ActiveRecord::Base.transaction do
+      CHANGES.each do |key, (from, to)|
+        update_attribute(key, from, to)
+      end
+    end
+  end
+
+  def down
+    ActiveRecord::Base.transaction do
+      CHANGES.each do |key, (to, from)|
+        update_attribute(key, from, to)
+      end
+    end
+  end
+
+  private
+
+  def update_attribute(name, from, to)
+    edits = DatasetEdit
+      .joins(:commit)
+      .where(
+        key: name, value: from, commits: {
+          message: 'Standaardwaarden op basis van Nederlandse gemiddelden'
+        }
+      )
+
+    say_with_time "Updating #{name} from #{from} to #{to}" do
+      edits.update_all(value: to)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181214125824) do
+ActiveRecord::Schema.define(version: 20181218173807) do
 
   create_table "commits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer  "source_id"


### PR DESCRIPTION
I updated *all* datasets which had the incorrect initial values, not just the Quintel datasets. This means that any third-party versions which contained the error are also fixed.

Closes quintel/etlocal#153