### PR TITLE
Distinguish RES region as area group

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -19,8 +19,10 @@ class Dataset < ApplicationRecord
       'district'
     elsif geo_id =~ /^BU/ or geo_id =~ /^BEBU/
       'neighbourhood'
-    elsif geo_id =~ /^RG/ or geo_id =~ /^RES/
+    elsif geo_id =~ /^RG/
       'region'
+    elsif geo_id =~ /^RES/
+      'res'
     else
       'province'
     end

--- a/config/locales/en_datasets.yml
+++ b/config/locales/en_datasets.yml
@@ -5,7 +5,7 @@ en:
       district: District
       neighbourhood: Neighbourhood
       province: Province
-      region: Region
+      region: RES region
 
     menu:
       static: Static

--- a/config/locales/en_datasets.yml
+++ b/config/locales/en_datasets.yml
@@ -5,7 +5,8 @@ en:
       district: District
       neighbourhood: Neighbourhood
       province: Province
-      region: RES region
+      region: Region
+      res: RES region
 
     menu:
       static: Static

--- a/config/locales/nl_datasets.yml
+++ b/config/locales/nl_datasets.yml
@@ -5,7 +5,7 @@ nl:
       district: Wijk
       neighbourhood: Buurt
       province: Provincie
-      region: Regio
+      region: RES-regio
 
     menu:
       static: Statisch

--- a/config/locales/nl_datasets.yml
+++ b/config/locales/nl_datasets.yml
@@ -5,7 +5,8 @@ nl:
       district: Wijk
       neighbourhood: Buurt
       province: Provincie
-      region: RES-regio
+      region: Regio
+      res: RES-regio
 
     menu:
       static: Statisch


### PR DESCRIPTION
- Distinguish `res` as area group when exporting the dataset to ETSource
- Add translations for the RES regions