### PR TITLE
Add food and paper electricity splits to front-end and database

### DIFF
--- a/config/interface_elements/industry/industry_food.yml
+++ b/config/interface_elements/industry/industry_food.yml
@@ -15,3 +15,13 @@ groups:
         unit: 'TJ'
       - key: input_industry_food_coal_demand
         unit: 'TJ'
+
+  - header: industry_food_electricity
+    type: slider
+    items:
+      - key: industry_final_demand_for_other_food_electricity_industry_useful_demand_for_other_food_electricity_parent_share
+        unit: '%'
+      - key: industry_final_demand_for_other_food_electricity_industry_other_food_heater_electricity_parent_share
+        unit: '%'
+        flexible: true
+        skip_validation: true

--- a/config/interface_elements/industry/industry_paper.yml
+++ b/config/interface_elements/industry/industry_paper.yml
@@ -15,3 +15,13 @@ groups:
         unit: 'TJ'
       - key: input_industry_paper_coal_demand
         unit: 'TJ'
+
+  - header: industry_paper_electricity
+    type: slider
+    items:
+      - key: industry_final_demand_for_other_paper_electricity_industry_useful_demand_for_other_paper_electricity_parent_share
+        unit: '%'
+      - key: industry_final_demand_for_other_paper_electricity_industry_other_paper_heater_electricity_parent_share
+        unit: '%'
+        flexible: true
+        skip_validation: true

--- a/config/locales/en_attributes.yml
+++ b/config/locales/en_attributes.yml
@@ -309,6 +309,9 @@ en:
         input_industry_food_hydrogen_demand: Hydrogen
         input_industry_food_coal_demand: Coal
 
+        industry_final_demand_for_other_food_electricity_industry_useful_demand_for_other_food_electricity_parent_share: Processes
+        industry_final_demand_for_other_food_electricity_industry_other_food_heater_electricity_parent_share: Heat
+
         input_industry_paper_electricity_demand: Electricity
         input_industry_paper_network_gas_demand: Gas
         input_industry_paper_steam_hot_water_demand: Heat
@@ -316,6 +319,9 @@ en:
         input_industry_paper_crude_oil_demand: Oil
         input_industry_paper_hydrogen_demand: Hydrogen
         input_industry_paper_coal_demand: Coal
+
+        industry_final_demand_for_other_paper_electricity_industry_useful_demand_for_other_paper_electricity_parent_share: Processes
+        industry_final_demand_for_other_paper_electricity_industry_other_paper_heater_electricity_parent_share: Heat
 
         input_industry_ict_electricity_demand: Electricity
 

--- a/config/locales/en_dataset_edits.yml
+++ b/config/locales/en_dataset_edits.yml
@@ -85,7 +85,9 @@ en:
       industry_chemical_refineries: Refineries
       industry_chemical_other: Other chemical industry
       industry_food: Food
+      industry_food_electricity: Electricity use
       industry_paper: Paper
+      industry_paper_electricity: Electricity use
       industry_ict: Central ICT services
       industry_other: Other industry sectors
 

--- a/config/locales/nl_attributes.yml
+++ b/config/locales/nl_attributes.yml
@@ -309,6 +309,9 @@ nl:
         input_industry_food_hydrogen_demand: Waterstof
         input_industry_food_coal_demand: Kolen
 
+        industry_final_demand_for_other_food_electricity_industry_useful_demand_for_other_food_electricity_parent_share: Processen
+        industry_final_demand_for_other_food_electricity_industry_other_food_heater_electricity_parent_share: Warmte
+
         input_industry_paper_electricity_demand: Elektriciteit
         input_industry_paper_network_gas_demand: Gas
         input_industry_paper_steam_hot_water_demand: Warmte
@@ -316,6 +319,9 @@ nl:
         input_industry_paper_crude_oil_demand: Olie
         input_industry_paper_hydrogen_demand: Waterstof
         input_industry_paper_coal_demand: Kolen
+
+        industry_final_demand_for_other_paper_electricity_industry_useful_demand_for_other_paper_electricity_parent_share: Processen
+        industry_final_demand_for_other_paper_electricity_industry_other_paper_heater_electricity_parent_share: Warmte
 
         input_industry_ict_electricity_demand: Elektriciteit
 

--- a/config/locales/nl_dataset_edits.yml
+++ b/config/locales/nl_dataset_edits.yml
@@ -87,7 +87,9 @@ nl:
       industry_chemical_refineries: Raffinaderijen
       industry_chemical_other: Overige chemische industrie
       industry_food: Voedsel
+      industry_food_electricity: Elektriciteitsgebruik
       industry_paper: Papier
+      industry_paper_electricity: Elektriciteitsgebruik
       industry_ict: Centrale ICT-diensten
       industry_other: Overige industrie
 

--- a/db/migrate/20200325172206_add_food_paper_electricity_splits.rb
+++ b/db/migrate/20200325172206_add_food_paper_electricity_splits.rb
@@ -1,0 +1,87 @@
+class AddFoodPaperElectricitySplits < ActiveRecord::Migration[5.2]
+ def up
+   new_keys = {
+    'industry_final_demand_for_other_food_electricity_industry_other_food_heater_electricity_parent_share' => 0.0,
+    'industry_final_demand_for_other_food_electricity_industry_useful_demand_for_other_food_electricity_parent_share' => 1.0,
+    'industry_final_demand_for_other_paper_electricity_industry_other_paper_heater_electricity_parent_share' => 0.0,
+    'industry_final_demand_for_other_paper_electricity_industry_useful_demand_for_other_paper_electricity_parent_share' => 1.0
+    }
+    say "Checking and migrating #{Dataset.count} datasets"
+    changed = 0
+
+    Dataset.find_each.with_index do |dataset, index|
+      if index.positive? && (index % 500).zero?
+        say "Done #{index} (#{changed} updated)"
+      end
+
+      ActiveRecord::Base.transaction do
+        com = Commit.create!(
+          user_id: 4,
+          dataset_id: dataset.id,
+          message: 'Gebaseerd op Nederlands gemiddelde'
+        )
+
+        new_keys.each do |key, value|
+          create_edit(com, key, value)
+        end
+      end
+      changed += 1
+    end
+
+    say "Finished (#{changed} updated)"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # Create a new dataset edit
+  def create_edit(commit, key, value)
+    ActiveRecord::Base.transaction do
+      DatasetEdit.create!(
+        commit_id: commit.id,
+        key: key,
+        value: value
+      )
+    end
+  end
+
+  # Finds all commits belonging to a dataset with an edit to the given key.
+  def find_commits(dataset, edit_key)
+    dataset.commits
+           .joins(:dataset_edits)
+           .where(dataset_edits: { key: edit_key })
+           .order(updated_at: :desc)
+  end
+
+  # Finds the most recent edit of a key belonging to a dataset.
+  def find_edit(dataset, edit_key)
+    commits = find_commits(dataset, edit_key)
+
+    return nil unless commits.any?
+
+    DatasetEdit
+      .where(commit_id: commits.pluck(:id), key: edit_key)
+      .order(updated_at: :desc)
+      .first
+  end
+
+  # Removes all dataset edits matching the `edit_key`. If the key is the only
+  # dataset belonging to the commit, the commit will also be removed.
+  def destroy_edits(dataset, edit_key)
+    commits = find_commits(dataset, edit_key)
+
+    return if commits.none?
+
+    commits.each do |commit|
+      if commit.dataset_edits.one?
+        commit.destroy
+      else
+        commit.dataset_edits.find_by_key(edit_key).destroy
+      end
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_10_170035) do
+ActiveRecord::Schema.define(version: 2020_03_25_173242) do
 
   create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"


### PR DESCRIPTION
Adds interface elements for the split of electricity demand of food and paper into processes and heat.
Migration to use default NL2015 value for all region