### PR TITLE
Add migration that updates block heating share for five regions

### DIFF
--- a/db/migrate/20200327080450_minor_update_regions_block_heating.rb
+++ b/db/migrate/20200327080450_minor_update_regions_block_heating.rb
@@ -1,0 +1,43 @@
+class MinorUpdateRegionsBlockHeating < ActiveRecord::Migration[5.0]
+  def self.up
+    directory    = Rails.root.join('db/migrate/20200327080450_minor_update_regions_block_heating')
+    data_path    = directory.join('data.csv')
+    commits_path = directory.join('commits.yml')
+    datasets     = []
+
+    # By default, CSVImporter only allows updating existing datasets. If the
+    # migration is adding a new dataset, add the `create_missing_datasets`
+    # keyword argument. For example:
+    #
+    #   CSVImporter.run(data_path, commits_path, create_missing_datasets: true) do |row, runner|
+    #     # ...
+    #   end
+    #
+    CSVImporter.run(data_path, commits_path) do |row, runner|
+      print "Updating #{row['geo_id']}... "
+      commits = runner.call
+
+      if commits.any?
+        datasets.push(find_dataset(commits))
+        puts 'done!'
+      else
+        puts 'nothing to change!'
+      end
+    end
+
+    sleep(1)
+    puts
+    puts "Updated #{datasets.length} datasets with the following IDs:"
+    puts "  #{datasets.map(&:id).join(',')}"
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def find_dataset(commits)
+    commits.each do |commit|
+      return commit.dataset if commit&.dataset
+    end
+  end
+end

--- a/db/migrate/20200327080450_minor_update_regions_block_heating/commits.yml
+++ b/db/migrate/20200327080450_minor_update_regions_block_heating/commits.yml
@@ -1,0 +1,5 @@
+---
+- fields:
+  - :all
+  message:
+    "Geen lokale informatie beschikbaar. Aanname: Nederlands gemiddelde. Bron: Vesta MAIS 4.0"

--- a/db/migrate/20200327080450_minor_update_regions_block_heating/data.csv
+++ b/db/migrate/20200327080450_minor_update_regions_block_heating/data.csv
@@ -1,0 +1,6 @@
+geo_id,heat_share_of_apartments_with_block_heating
+RES11,0.15
+RES19,0.15
+RES31,0.15
+PV31,0.15
+PV28,0.15

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_173242) do
+ActiveRecord::Schema.define(version: 2020_03_27_080450) do
 
   create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"


### PR DESCRIPTION
These five regions had a `heat_share_of_apartments_with_block_heating` higher than 1.0. Updated the value to the Dutch average value