### PR TITLE
Remove country defaults and calc base_dataset for Datasets

### DIFF
--- a/app/controllers/api/v1/exports_controller.rb
+++ b/app/controllers/api/v1/exports_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ExportsController < ApplicationController
     json = datasets.map do |dataset|
       dataset.editable_attributes.as_json.merge(
         area: "#{dataset.geo_id}_#{dataset.normalized_name}",
-        base_dataset: dataset.country,
+        base_dataset: dataset.base_dataset,
         group: dataset.group,
         time_curves_to_zero: params[:time_curves_to_zero]
       )

--- a/app/controllers/commits_controller.rb
+++ b/app/controllers/commits_controller.rb
@@ -9,7 +9,7 @@ class CommitsController < ApplicationController
   # GET new
   def new
     @dataset_edit_form = DatasetEditForm.new(
-      @dataset.editable_attributes.as_json
+      @dataset.editable_attributes.as_json.merge(country: @dataset.country)
     )
   end
 
@@ -17,7 +17,9 @@ class CommitsController < ApplicationController
   def dataset_edits
     authorize @dataset, :update?
 
-    @dataset_edit_form = DatasetEditForm.new(dataset_edit_params.to_h)
+    @dataset_edit_form = DatasetEditForm.new(
+      dataset_edit_params.to_h.merge(country: @dataset.country)
+    )
     @commit = @dataset_edit_form.submit(@dataset)
   end
 
@@ -27,7 +29,7 @@ class CommitsController < ApplicationController
 
     if @commit.save
       @dataset_edit_form = DatasetEditForm.new(
-        @dataset.editable_attributes.as_json
+        @dataset.editable_attributes.as_json.merge(country: @dataset.country)
       )
 
       flash.now[:success] = I18n.t(

--- a/app/forms/dataset_edit_form.rb
+++ b/app/forms/dataset_edit_form.rb
@@ -6,7 +6,11 @@ class DatasetEditForm
     attribute item.key, Float, default: item.default
   end
 
-  validates_presence_of :number_of_residences
+  # Attribute country is needed to validate the user inputs
+  # in the form (see CalculableValidator)
+  attribute :country, String
+
+  validates_presence_of :number_of_residences, :country
   validates :number_of_residences, numericality: { greater_than: 0 }
   validates_with CalculableValidator
 
@@ -16,7 +20,7 @@ class DatasetEditForm
       commit = dataset.commits.build
       commit.build_source
 
-      attributes.each_pair do |key, val|
+      attributes.except(:country).each_pair do |key, val|
         if val.present? && previous[key.to_s] != val
           commit.dataset_edits.build(
             key: key,
@@ -25,7 +29,8 @@ class DatasetEditForm
         end
       end
 
-      commit
+      return commit
     end
+    puts errors.full_messages
   end
 end

--- a/app/models/etsource.rb
+++ b/app/models/etsource.rb
@@ -7,6 +7,10 @@ module Etsource
     end]
   end
 
+  def available_countries
+    @available_countries ||= Atlas::Dataset::Full.all.map{ |d| d.area }
+  end
+
   # Returns all dataset input keys from sparse graph queries
   # Used to check if an interface element is still required.
   def dataset_inputs

--- a/app/services/calculable_validator.rb
+++ b/app/services/calculable_validator.rb
@@ -5,17 +5,22 @@ class CalculableValidator < ActiveModel::Validator
     )
 
     begin
-      dataset = Dataset.new(name: 'calculation_shell')
+      dataset = Dataset.new(
+        name: 'calculation_shell',
+        country: record.attributes[:country]
+      )
+
       CalculateContainer.new(
         calc_attrs.merge(
           area: dataset.temp_name,
-          base_dataset: dataset.country
+          base_dataset: dataset.base_dataset
         )
       ).tryout!
 
     rescue Refinery::IncalculableGraphError,
            Refinery::FailedValidationError,
            Atlas::QueryError,
+           Atlas::DocumentNotFoundError,
            ArgumentError => error
       record.errors.add(:calculation, error.message)
     end

--- a/app/services/csv_importer.rb
+++ b/app/services/csv_importer.rb
@@ -136,7 +136,9 @@ class CSVImporter
     datasets = Dataset.where(geo_id: row['geo_id'], user: User.robot)
 
     if @create_missing && datasets.none?
-      Dataset.create!(row.to_h.slice('geo_id', 'name').merge(user: User.robot))
+      Dataset.create!(
+        row.to_h.slice('geo_id', 'name', 'country').merge(user: User.robot)
+      )
     else
       datasets.first!
     end

--- a/app/services/csv_importer/schema.rb
+++ b/app/services/csv_importer/schema.rb
@@ -20,12 +20,12 @@ class CSVImporter
 
     # Public: Headers which are required to be present in the data file.
     def mandatory_headers
-      @name_required ? %w[geo_id name] : %w[geo_id]
+      @name_required ? %w[geo_id country name] : %w[geo_id]
     end
 
     # Public: Headers which may be omitted.
     def optional_headers
-      @name_required ? [] : %w[name]
+      @name_required ? [] : %w[name country]
     end
 
     # Public: Headers which a CSV may optionally include.

--- a/app/services/exporter.rb
+++ b/app/services/exporter.rb
@@ -11,9 +11,11 @@ module Exporter
       content_type: :json
     )
 
+    #SKIP IF NOT IN ATLAS
     JSON.parse(response).each do |dataset|
+      puts "Generating #{dataset['area']} with base set #{dataset['base_dataset']}"
       Transformer::DatasetGenerator.new(dataset).generate
-      puts "Successfully analyzed and exported #{dataset[:name]}"
+      puts "Successfully analyzed and exported #{dataset['area']}"
     end
   rescue RestClient::ExceptionWithResponse
     puts "Failed to fetch data for #{dataset_ids}"

--- a/db/migrate/20200424141616_remove_default_nl_for_dataset_country.rb
+++ b/db/migrate/20200424141616_remove_default_nl_for_dataset_country.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultNlForDatasetCountry < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :datasets, :country, nil
+  end
+
+  def down
+    change_column_default :datasets, :country, 'nl'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_164014) do
     t.integer "user_id"
     t.string "name", default: "", null: false
     t.string "geo_id", default: "", null: false
-    t.string "country", default: "nl"
+    t.string "country"
     t.boolean "has_industry", default: false
     t.boolean "has_agriculture", default: false
     t.boolean "public", default: true

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     user
     geo_id { 'ameland' }
     name { 'ameland' }
+    country { 'nl' }
   end
 end

--- a/spec/fixtures/seeds/data.csv
+++ b/spec/fixtures/seeds/data.csv
@@ -1,5 +1,5 @@
-geo_id,name,number_of_inhabitants,number_of_residences,number_of_cars,households_final_demand_electricity_demand,households_final_demand_network_gas_demand,residences_roof_surface_available_for_pv
-BU22168000,Wijk 01 Annen,155,60,95,4930,2330,31.01
-BU22168001,Wijk 02 Eext,1225,530,715,3330,1900,24.8530057
-BU22168002,Wijk 03 Eext,155,80,105,3600,2210,41.12
-BU22168003,Wijk 04 Anloo,330,150,195,3430,2100,123.1
+geo_id,name,country,number_of_inhabitants,number_of_residences,number_of_cars,households_final_demand_electricity_demand,households_final_demand_network_gas_demand,residences_roof_surface_available_for_pv
+BU22168000,Wijk 01 Annen,nl,155,60,95,4930,2330,31.01
+BU22168001,Wijk 02 Eext,nl,1225,530,715,3330,1900,24.8530057
+BU22168002,Wijk 03 Eext,nl,155,80,105,3600,2210,41.12
+BU22168003,Wijk 04 Anloo,nl,330,150,195,3430,2100,123.1

--- a/spec/forms/dataset_edit_form_spec.rb
+++ b/spec/forms/dataset_edit_form_spec.rb
@@ -12,7 +12,8 @@ describe DatasetEditForm do
 
     it "has a negative number of residences" do
       commit_form = DatasetEditForm.new(
-        number_of_residences: -1
+        number_of_residences: -1,
+        country: 'nl'
       )
 
       expect(commit_form.valid?).to eq(false)
@@ -20,7 +21,16 @@ describe DatasetEditForm do
 
     it "number of residences is 0" do
       commit_form = DatasetEditForm.new(
-        number_of_residences: 0
+        number_of_residences: 0,
+        country: 'nl'
+      )
+
+      expect(commit_form.valid?).to eq(false)
+    end
+
+    it "has no country set" do
+      commit_form = DatasetEditForm.new(
+        number_of_residences: 1
       )
 
       expect(commit_form.valid?).to eq(false)
@@ -29,7 +39,8 @@ describe DatasetEditForm do
 
   it 'has all the attributes of the transformer dataset cast' do
     commit_form = DatasetEditForm.new(
-      number_of_residences: 50
+      number_of_residences: 50,
+      country: 'nl'
     )
 
     expect(commit_form.valid?).to eq(true)
@@ -37,7 +48,7 @@ describe DatasetEditForm do
 
   context "submitting" do
     let(:commit_form) {
-      DatasetEditForm.new(number_of_residences: 20)
+      DatasetEditForm.new(number_of_residences: 20, country: 'nl')
     }
 
     it "build a dataset edit for commit" do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Dataset do
   let(:dataset) {
-    Dataset.new(name: "Ameland")
+    Dataset.new(name: "Ameland", country: 'nl')
   }
 
   it "it initializes a dataset from an Atlas dataset" do
@@ -11,5 +11,33 @@ describe Dataset do
 
   it "expects a name attribute to be present" do
     expect(dataset.name).to eq("Ameland")
+  end
+
+  it 'has a base dataset' do
+    expect(dataset.base_dataset).to eq 'nl'
+  end
+
+  context 'with a country not in ETsource' do
+    let(:mars_dataset) do
+      Dataset.new(
+        name: 'Tharsis', country: 'mars', user: User.robot, geo_id: 'GM666'
+      )
+    end
+
+    it 'is not valid' do
+      expect(mars_dataset.valid?).to be_falsey
+    end
+  end
+
+  context 'with a country in ETsource' do
+    let(:ameland_dataset) do
+      Dataset.new(
+        name: 'Ameland', country: 'nl', user: User.robot, geo_id: 'GM3040'
+      )
+    end
+
+    it 'is valid' do
+      expect(ameland_dataset.valid?).to be_truthy
+    end
   end
 end

--- a/spec/services/csv_importer/schema_spec.rb
+++ b/spec/services/csv_importer/schema_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe CSVImporter::Schema do
         expect(schema.mandatory_headers).to include('geo_id')
       end
 
+      it 'does not have "country" as a mandatory header' do
+        expect(schema.mandatory_headers).not_to include('country')
+      end
+
+      it 'has "country" as a optional header' do
+        expect(schema.optional_headers).to include('country')
+      end
+
       it 'does not have "name" as an mandatory header' do
         expect(schema.mandatory_headers).not_to include('name')
       end
@@ -36,7 +44,15 @@ RSpec.describe CSVImporter::Schema do
         expect(schema.mandatory_headers).to include('geo_id')
       end
 
-      it 'has "name" as n mandatory header' do
+      it 'has "country" as a mandatory header' do
+        expect(schema.mandatory_headers).to include('country')
+      end
+
+      it 'does not have "country" as an optional header' do
+        expect(schema.optional_headers).not_to include('country')
+      end
+
+      it 'has "country" as n mandatory header' do
         expect(schema.mandatory_headers).to include('name')
       end
 

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -93,8 +93,8 @@ RSpec.describe CSVImporter do
 
       let(:data) do
         <<~CSV
-          geo_id,name,number_of_residences
-          GM0340,My First Area,5
+          geo_id,name,country,number_of_residences
+          GM0340,My First Area,nl,5
         CSV
       end
 
@@ -119,8 +119,8 @@ RSpec.describe CSVImporter do
 
       let(:data) do
         <<~CSV
-          geo_id,name,number_of_residences
-          GM0340,,5
+          geo_id,name,country,number_of_residences
+          GM0340,,nl,5
         CSV
       end
 
@@ -151,8 +151,8 @@ RSpec.describe CSVImporter do
 
       let(:data) do
         <<~CSV
-          geo_id,name,number_of_residences
-          GM0340,My First Area,5
+          geo_id,name,country,number_of_residences
+          GM0340,My First Area,nl,5
         CSV
       end
 
@@ -647,7 +647,8 @@ RSpec.describe CSVImporter do
       expect { importer.run }.to raise_error(/no dataset exists matching/i)
     end
 
-    context 'with create_missing_datasets: true and no "name" in the CSV' do
+    context 'with create_missing_datasets: true
+      and no name or country in the CSV' do
       let(:importer) do
         described_class.new(
           data_csv.path,
@@ -658,11 +659,12 @@ RSpec.describe CSVImporter do
 
       it 'raises an error' do
         expect { importer.run }
-          .to raise_error(/is missing mandatory headers: "name"/i)
+          .to raise_error(/is missing mandatory headers: "country", "name"/i)
       end
     end
 
-    context 'with create_missing_datasets: true and a blank "name" in the CSV' do
+    context 'with create_missing_datasets: true
+      and a blank "name" in the CSV' do
       let(:importer) do
         described_class.new(
           data_csv.path,
@@ -673,8 +675,8 @@ RSpec.describe CSVImporter do
 
       let(:data) do
         <<~CSV
-          geo_id,name,number_of_inhabitants
-          GM0340,,5
+          geo_id,country,name,number_of_inhabitants
+          GM0340,nl,,5
         CSV
       end
 
@@ -683,7 +685,8 @@ RSpec.describe CSVImporter do
       end
     end
 
-    context 'with create_missing_datasets: true and an "name" in the CSV' do
+    context 'with create_missing_datasets: true
+      and a blank "country" in the CSV' do
       let(:importer) do
         described_class.new(
           data_csv.path,
@@ -694,8 +697,31 @@ RSpec.describe CSVImporter do
 
       let(:data) do
         <<~CSV
-          geo_id,name,number_of_inhabitants
-          GM0340,My First Area,5
+          geo_id,country,name,number_of_inhabitants
+          GM0340,,My First Area,5
+        CSV
+      end
+
+      it 'raises an error' do
+        expect { importer.run }.to raise_error(/Country can't be blank/i)
+      end
+    end
+
+    context 'with create_missing_datasets: true
+      and name and country in the CSV' do
+
+      let(:importer) do
+        described_class.new(
+          data_csv.path,
+          commits_yml.path,
+          create_missing_datasets: true
+        )
+      end
+
+      let(:data) do
+        <<~CSV
+          geo_id,country,name,number_of_inhabitants
+          GM0340,nl,My First Area,5
         CSV
       end
 
@@ -803,8 +829,8 @@ RSpec.describe CSVImporter do
 
     let(:data) do
       <<~CSV
-        geo_id,name,number_of_residences
-        GM0340,ABC,5
+        geo_id,country,name,number_of_residences
+        GM0340,nl,ABC,5
       CSV
     end
 

--- a/spec/services/dataset_importer_spec.rb
+++ b/spec/services/dataset_importer_spec.rb
@@ -16,7 +16,12 @@ describe DatasetImporter do
     let(:user) { User.robot }
 
     let!(:dataset) do
-      FactoryBot.create(:dataset, geo_id: 'BU22168000', user: user)
+      FactoryBot.create(
+        :dataset,
+        geo_id: 'BU22168000',
+        country:'nl',
+        user: user
+      )
     end
 
     let!(:commit) do


### PR DESCRIPTION
Add validation of country: needs to be a full Atlas set
Calculate base_dataset by combining country and analysis_year and checking if this is a full Atlas set. Default to country.
Adjust specs, exporter and edit-forms to work with base_dataset and without country default