### PR TITLE
Adding hydro power mountain production

### DIFF
--- a/config/interface_elements/energy/energy_renewable_electricity_production.yml
+++ b/config/interface_elements/energy/energy_renewable_electricity_production.yml
@@ -20,7 +20,7 @@ groups:
         unit: 'TJ'
       - key: input_energy_chp_supercritical_waste_mix_production
         unit: 'TJ'
-        
+
   - header: energy_electricity_other_renewable
     items:
       - key: input_energy_chp_local_wood_pellets_production
@@ -28,6 +28,8 @@ groups:
       - key: input_energy_chp_local_engine_biogas_production
         unit: 'TJ'
       - key: input_energy_power_hydro_river_production
+        unit: 'TJ'
+      - key: input_energy_power_hydro_mountain_production
         unit: 'TJ'
       - key: input_energy_power_geothermal_production
         unit: 'TJ'

--- a/config/locales/en_attributes.yml
+++ b/config/locales/en_attributes.yml
@@ -364,6 +364,7 @@ en:
         input_energy_power_supercritical_waste_mix_production: Waste incinerator
         input_energy_chp_supercritical_waste_mix_production: Waste plant with heat production for district heat (CHP)
         input_energy_power_hydro_river_production: Hydro (river)
+        input_energy_power_hydro_mountain_production: Hydro (mountain)
         input_energy_power_geothermal_production: Geothermal
         input_energy_chp_local_engine_biogas_production: Biogas CHP
         input_energy_chp_local_wood_pellets_production: Biomass CHP

--- a/config/locales/nl_attributes.yml
+++ b/config/locales/nl_attributes.yml
@@ -364,6 +364,7 @@ nl:
         input_energy_power_supercritical_waste_mix_production: Afvalverbrander
         input_energy_chp_supercritical_waste_mix_production: Afvalverbrander met warmtelevering voor warmtenet (WKK)
         input_energy_power_hydro_river_production: Waterkracht (rivier)
+        input_energy_power_hydro_mountain_production: Waterkracht (bergen)
         input_energy_power_geothermal_production: Geothermie
         input_energy_chp_local_engine_biogas_production: Biogas WKK
         input_energy_chp_local_wood_pellets_production: Biomassa WKK

--- a/db/migrate/20200605081642_add_hydro_mountain_demand.rb
+++ b/db/migrate/20200605081642_add_hydro_mountain_demand.rb
@@ -1,0 +1,83 @@
+class AddHydroMountainDemand < ActiveRecord::Migration[5.2]
+  def up
+    new_keys = {
+     'input_energy_power_hydro_mountain_production' => 0.0
+     }
+     say "Checking and migrating #{Dataset.count} datasets"
+     changed = 0
+
+     Dataset.find_each.with_index do |dataset, index|
+       if index.positive? && (index % 500).zero?
+         say "Done #{index} (#{changed} updated)"
+       end
+
+       ActiveRecord::Base.transaction do
+         com = Commit.create!(
+           user_id: 4,
+           dataset_id: dataset.id,
+           message: 'Geen bergen in deze regio, dus ook geen waterkracht (bergen) beschikbaar'
+         )
+
+         new_keys.each do |key, value|
+           create_edit(com, key, value)
+         end
+       end
+       changed += 1
+     end
+
+     say "Finished (#{changed} updated)"
+   end
+
+   def down
+     raise ActiveRecord::IrreversibleMigration
+   end
+
+   private
+
+   # Create a new dataset edit
+   def create_edit(commit, key, value)
+     ActiveRecord::Base.transaction do
+       DatasetEdit.create!(
+         commit_id: commit.id,
+         key: key,
+         value: value
+       )
+     end
+   end
+
+   # Finds all commits belonging to a dataset with an edit to the given key.
+   def find_commits(dataset, edit_key)
+     dataset.commits
+            .joins(:dataset_edits)
+            .where(dataset_edits: { key: edit_key })
+            .order(updated_at: :desc)
+   end
+
+   # Finds the most recent edit of a key belonging to a dataset.
+   def find_edit(dataset, edit_key)
+     commits = find_commits(dataset, edit_key)
+
+     return nil unless commits.any?
+
+     DatasetEdit
+       .where(commit_id: commits.pluck(:id), key: edit_key)
+       .order(updated_at: :desc)
+       .first
+   end
+
+   # Removes all dataset edits matching the `edit_key`. If the key is the only
+   # dataset belonging to the commit, the commit will also be removed.
+   def destroy_edits(dataset, edit_key)
+     commits = find_commits(dataset, edit_key)
+
+     return if commits.none?
+
+     commits.each do |commit|
+       if commit.dataset_edits.one?
+         commit.destroy
+       else
+         commit.dataset_edits.find_by_key(edit_key).destroy
+       end
+     end
+   end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_27_131501) do
+ActiveRecord::Schema.define(version: 2020_06_05_081642) do
 
   create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"


### PR DESCRIPTION
Before hydro mountain production was derived from the parent country of a dataset. For Northern Ireland this resulted in some hydro mountain production, because the UK has hydro power in mountains. Therefore, the demand can now be set in ETLocal and has been set to zero for all ETLocal dataset as there is no hydro power in mountains :)