### PR TITLE
Replace map search with dataset seacrh

### DIFF
--- a/app/assets/javascripts/areas/areas.search.js
+++ b/app/assets/javascripts/areas/areas.search.js
@@ -77,6 +77,10 @@ Areas.Search = (function () {
                     alert(e);
                 }
             });
+        },
+
+        hideOptions: function () {
+            this.scope.find('.options').remove();
         }
     };
 
@@ -84,6 +88,7 @@ Areas.Search = (function () {
         this.areas = areas;
         this.scope = scope;
         this.scope.on('submit', this.handleSubmit.bind(this));
+        this.scope.find('#search-bar').on('input', this.hideOptions.bind(this));
     }
 
     return Search;

--- a/app/assets/javascripts/areas/areas.search.js
+++ b/app/assets/javascripts/areas/areas.search.js
@@ -30,25 +30,41 @@ Areas.Search = (function () {
 
         if (data.length == 1) {
             openPopup.call(this, data[0].id);
-        } else if (data.length > 1){
-            var list = $('<ul></ul>').addClass('options'),
-                self = this;
+        } else {
+            var list = $('<ul></ul>').addClass('options');
 
-            // Create an option in the list for each dataset
-            $.each(data, function(_key, dataset) {
-                var option = $('<li>' + dataset.name +' (' + dataset.id +')</li>');
-                option.on('click', function() {
-                    openPopup.call(self, dataset.id);
-                });
-                list.append(option);
-            })
+            // Create an option in the list for each dataset if there were multiple results
+            if (data.length > 1){
+                var self = this;
+
+                $.each(data, function(_key, dataset) {
+                    var option = $('<li>' + dataset.name +' (' + dataset.id +')</li>');
+                    option.on('click', function() {
+                        openPopup.call(self, dataset.id);
+                    });
+                    list.append(option);
+                })
+            } else {
+                list.append('<li>No results</li>');
+                this.scope
+                    .addClass("no-results")
+                    .attr('title', "No results for: " + this.result.value)
+            }
 
             this.scope.append(list);
-        } else {
-            this.scope
-                .addClass("no-results")
-                .attr('title', "No results for: " + this.result.value);
+            bindOptionsListener.call(this);
         }
+    }
+
+    // Removes options when clicking anywhere in the document
+    function bindOptionsListener() {
+        var options = this.scope.find('.options');
+        $(document).on('mouseup.hideOptionsClick', function(e) {
+            if (!options.is(e.target) && options.has(e.target).length === 0){
+                options.remove();
+                $(document).off('.hideOptionsClick');
+            }
+        })
     }
 
     Search.prototype = {

--- a/app/assets/stylesheets/areas.sass
+++ b/app/assets/stylesheets/areas.sass
@@ -129,6 +129,26 @@ $map-height: 100%
           background-color: $bg-color
           border-radius: 0 4px 4px 0
 
+        ul.options
+          background-color: $bg-color
+          border: 1px solid #bbb
+          border-radius: 4px
+          list-style: none
+          width: 290px
+          padding: 4px
+          li
+            padding: 5px
+            border-radius: 4px
+            &:hover
+              cursor: pointer
+              background-color: $selected-color
+              color: #fff
+            &:active
+              background-color: darken($selected-color, 5)
+            &:last-child
+              margin-bottom: 0
+
+
     #dataset-overlay
       position: relative
       display: none

--- a/app/assets/stylesheets/areas.sass
+++ b/app/assets/stylesheets/areas.sass
@@ -119,6 +119,10 @@ $map-height: 100%
         form.no-results
           input#search-bar
             border: 1px solid $error-color
+          ul li:hover
+            cursor: auto
+            background-color: $bg-color
+            color: #000
 
         input#search-bar
           border: 1px solid #bbb

--- a/app/assets/stylesheets/areas.sass
+++ b/app/assets/stylesheets/areas.sass
@@ -136,6 +136,8 @@ $map-height: 100%
           list-style: none
           width: 290px
           padding: 4px
+          max-height: 300px
+          overflow: scroll
           li
             padding: 5px
             border-radius: 4px

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -2,7 +2,7 @@ class DatasetsController < ApplicationController
   layout false, only: %i(edit clone)
   format 'js', only: %i(edit :clone)
 
-  before_action :authenticate_user!, except: %i(index show edit)
+  before_action :authenticate_user!, except: %i(index show edit search)
   before_action :find_dataset, only: %i(validate edit download clone)
 
   # GET index
@@ -26,6 +26,12 @@ class DatasetsController < ApplicationController
     dataset = Dataset.find_by(geo_id: params[:id])
 
     render json: dataset
+  end
+
+  # GET search.json
+  def search
+    results = Dataset.fuzzy_search(params[:query])
+    render json: results.map { |d| { id: d.geo_id, name: d.name } }.uniq
   end
 
   # POST download

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -18,6 +18,12 @@ class Dataset < ApplicationRecord
       .order(Arel.sql("FIELD(`id`, #{dataset.id}) DESC, `created_at` DESC"))
   end
 
+  # Search for query in geo_id and name - works kind of fine, but not as fuzzy as I hoped
+  def self.fuzzy_search(query)
+    pattern = "%#{query}%"
+    where(arel_table[:geo_id].matches(pattern)).or(where(arel_table[:name].matches(pattern)))
+  end
+
   def group
     if geo_id =~ /^GM/ or geo_id =~ /^BEGM/
       'municipality'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   resources :datasets, only: %i(index edit show) do
     get :download
 
+    get :search, on: :collection
+
     post :clone
 
     resources :commits, only: %i(create) do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Dataset do
   let(:dataset) {
-    Dataset.new(name: "Ameland", country: 'nl')
+    Dataset.create!(name: 'Ameland', country: 'nl', geo_id: 'AM31049', user: User.robot)
   }
 
   it "it initializes a dataset from an Atlas dataset" do
@@ -38,6 +38,28 @@ describe Dataset do
 
     it 'is valid' do
       expect(ameland_dataset.valid?).to be_truthy
+    end
+  end
+
+  describe '.fuzzy_search' do
+    subject { described_class.fuzzy_search(query) }
+
+    let(:eland) do
+      Dataset.create!(name: 'Eland', country: 'nl', geo_id: 'AM3568', user: User.robot)
+    end
+
+    context 'with an exactly matching geo_id query' do
+      let(:query) { 'AM31049' }
+
+      it { is_expected.to include(dataset) }
+      it { is_expected.to_not include(eland) }
+    end
+
+    context 'with an fuzzy matching name query' do
+      let(:query) { 'land' }
+
+      it { is_expected.to include(dataset) }
+      it { is_expected.to include(eland) }
     end
   end
 end


### PR DESCRIPTION
I replaced the current map based search with a dataset based search.

You can put in either a geoID or a dataset name, and a fuzzy search is performed. The fuzzy search ignores lower/uppercase, and looks for the input to be _part_ of a name or geoID. So the input _"rot"_ for example gives the options of Rotterdam, RES regio Rotterdam-Den Haag, but also Grote Plas. This fuzzy search does not corect typos.

<img width="1273" alt="Screenshot 2021-02-15 at 15 01 26" src="https://user-images.githubusercontent.com/14875123/107955923-b230f180-6f9e-11eb-919f-06ba9d6892ba.png">

You can click one of the search results (or when there is only one result, this happens immeadiatly) and the dataset opens in the well known pop-up.

Closes #255 