### PR TITLE
Rebuild dataset on default when exporting to etsource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'archive-zip', '~> 0.9.0'
 gem 'sentry-raven'
 gem 'deep_cloneable', '~> 2.3.0'
 
-gem 'transformer', ref: 'd7bfe08', github: 'quintel/transformer'
+gem 'transformer', ref: 'cc414cd', github: 'quintel/transformer'
 gem 'atlas',       ref: 'a560290', github: 'quintel/atlas'
 gem 'rubel',       ref: 'ad3d44e', github: 'quintel/rubel'
 gem 'refinery',    ref: '72eacf8', github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/transformer.git
-  revision: d7bfe08a62597bd007e99718c6b499587d1b6851
-  ref: d7bfe08
+  revision: cc414cd9b12820982ef28d6483eadb07bcaface0
+  ref: cc414cd
   specs:
     transformer (1.0.0)
       atlas (~> 1.0)

--- a/app/services/exporter.rb
+++ b/app/services/exporter.rb
@@ -3,21 +3,28 @@
 module Exporter
   DATASET_URL = "#{Rails.configuration.etsource_export_root}/api/v1".freeze
 
-  # Public: Exports an ETLocal dataset to an ETSource dataset.
-  def self.export(dataset_ids, time_curves_to_zero=false)
-    response = RestClient.get(
-      "#{DATASET_URL}/exports/#{dataset_ids}?time_curves_to_zero=#{time_curves_to_zero}",
-      accept: :json,
-      content_type: :json
-    )
+  class << self
+    # Public: Exports an ETLocal dataset to an ETSource dataset.
+    def export(dataset_ids, time_curves_to_zero: true, rebuild: true)
+      response = RestClient.get(
+        "#{DATASET_URL}/exports/#{dataset_ids}?time_curves_to_zero=#{time_curves_to_zero}",
+        accept: :json,
+        content_type: :json
+      )
 
-    #SKIP IF NOT IN ATLAS
-    JSON.parse(response).each do |dataset|
+      JSON.parse(response).each { |dataset| transform_dataset(dataset, rebuild) }
+    rescue RestClient::ExceptionWithResponse
+      puts "Failed to fetch data for #{dataset_ids}"
+    end
+
+    private
+
+    def transform_dataset(dataset, rebuild)
       puts "Generating #{dataset['area']} with base set #{dataset['base_dataset']}"
-      Transformer::DatasetGenerator.new(dataset).generate
+      transformer = Transformer::DatasetGenerator.new(dataset)
+      transformer.destroy if rebuild
+      transformer.generate
       puts "Successfully analyzed and exported #{dataset['area']}"
     end
-  rescue RestClient::ExceptionWithResponse
-    puts "Failed to fetch data for #{dataset_ids}"
   end
 end

--- a/lib/tasks/etsource.rake
+++ b/lib/tasks/etsource.rake
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 namespace :etsource do
-  desc <<-eos
+  desc <<-DESC
     Exports changes of a dataset to ETSource
 
     Requires a DATASET argument. It exports data from a remote source which
@@ -8,13 +10,23 @@ namespace :etsource do
     for localhost use:
     - localhost:3000
 
-    for beta use:
-    - beta-local.energytransitionmodel.com
+    for production use:
+    - data.energytransitionmodel.com
 
-  eos
-  task :export => :environment do
-    raise ArgumentError, "DATASET= argument is missing" unless ENV['DATASET']
+    Optional argument TIME_CURVES_TO_ZERO, default true, does not scale
+    timecurves when set to true.
 
-    Exporter.export(ENV['DATASET'], ENV['TIME_CURVES_TO_ZERO'])
+    Optional argument REBUILD, default true, removes the dataset folder from
+    ETSource before generating a new set when true. This means a new dataset id
+    in ETSource is generated, the old one will be removed
+
+  DESC
+
+  task export: :environment do
+    raise ArgumentError, 'DATASET= argument is missing' unless ENV['DATASET']
+
+    rebuild = ENV['REBUILD'].nil? or ENV['REBUILD'] == 'true'
+    time_curves_to_zero = ENV['TIME_CURVES_TO_ZERO'].nil? or ENV['TIME_CURVES_TO_ZERO'] == 'true'
+    Exporter.export(ENV['DATASET'], time_curves_to_zero: time_curves_to_zero, rebuild: rebuild)
   end
 end

--- a/spec/services/exporter_spec.rb
+++ b/spec/services/exporter_spec.rb
@@ -5,7 +5,7 @@ describe Exporter do
   let(:dataset) { FactoryBot.create(:dataset) }
 
   let!(:stub_export_request) {
-    stub_request(:get, "https://beta-local.energytransitionmodel.com/api/v1/exports/#{dataset.id}?time_curves_to_zero=false")
+    stub_request(:get, "https://beta-local.energytransitionmodel.com/api/v1/exports/#{dataset.id}?time_curves_to_zero=true")
       .to_return(body: JSON.dump([{
         'area' => 'ameland',
         'country' => 'nl',
@@ -26,7 +26,7 @@ describe Exporter do
   }
 
   it "exports a dataset" do
-    Exporter.export(dataset.id)
+    Exporter.export(dataset.id, rebuild: false)
 
     expect(Atlas::Dataset::Derived.find('ameland').number_of_cars).to eq(10)
   end


### PR DESCRIPTION
The task `etsource:export` now takes the optional argument `REBUILD` which defaults to true if not set. The dataset is detroyed before being build back up again,  this ensures symlinks and scaled data being up to date.

I also set the default for `TIME_CURVES_TO_ZERO` from false to true. With no parameters other than the datasets, the task now rebuilds and does not scale time curves (but sets them to zero).

Closes #250 