### PR TITLE
Restyle the version history

### DIFF
--- a/app/assets/stylesheets/style.sass
+++ b/app/assets/stylesheets/style.sass
@@ -327,28 +327,16 @@ div.history, div.information
   .change
     margin-bottom: 6px
     padding: 12px 0
-
-    .history-line
-      font-size: 80%
-      position: relative
-      text-align: center
-
-      span.border
-        border-bottom: 1px solid darken($border-color, 10)
-        height: 1px
-        display: block
-        width: 100%
-        margin-bottom: -10px
-
-      span.line
-        background-color: #eee
-        padding: 0 10px
+    display: flex
+    justify-content: space-between
+    .created_by
+      padding-right: 10px
+      .created, .by
+        font-size: 1.25rem
         color: #999
-
-    .content
-      margin-top: 10px
+    .reason
       text-align: justify
-
+      width: 400px
     .source
       margin-top: 10px
       text-align: right

--- a/app/models/dataset_edit.rb
+++ b/app/models/dataset_edit.rb
@@ -12,6 +12,10 @@ class DatasetEdit < ApplicationRecord
     commit.user
   end
 
+  def creator
+    user.group ? user.group.key.humanize : user.name
+  end
+
   def as_json(*)
     super.slice('key', 'value')
   end

--- a/app/views/interface_elements/_interface_element.slim
+++ b/app/views/interface_elements/_interface_element.slim
@@ -65,6 +65,7 @@
         .history.hidden class= interface_item.key
           .line-arrow
 
+          / # HIERRR
           - if I18n.exists?("descriptions.interface_items.#{interface_item.key}")
             p=I18n.t("descriptions.interface_items.#{interface_item.key}").html_safe
 
@@ -78,7 +79,7 @@
                   span.created
                     => I18n.l dataset_edit.created_at, format: :short
                   span.by
-                    => I18n.t("dataset_edits.changed_by", user: dataset_edit.commit.user.name)
+                    => I18n.t("dataset_edits.changed_by", user: dataset_edit.creator)
                   span.to
                     | &rarr;
                     | &nbsp;

--- a/app/views/interface_elements/_interface_element.slim
+++ b/app/views/interface_elements/_interface_element.slim
@@ -65,32 +65,23 @@
         .history.hidden class= interface_item.key
           .line-arrow
 
-          / # HIERRR
           - if I18n.exists?("descriptions.interface_items.#{interface_item.key}")
             p=I18n.t("descriptions.interface_items.#{interface_item.key}").html_safe
 
-          strong = I18n.t("dataset_edits.history")
+          strong= I18n.t("dataset_edits.history")
 
           - @dataset.editable_attributes.edits_for(interface_item.key).each do |dataset_edit|
             .change
-              .history-line
-                span.border
-                span.line
-                  span.created
-                    => I18n.l dataset_edit.created_at, format: :short
-                  span.by
-                    => I18n.t("dataset_edits.changed_by", user: dataset_edit.creator)
-                  span.to
-                    | &rarr;
-                    | &nbsp;
-                    = dataset_edit.value
+              .created_by
+                .to
+                  => I18n.t("dataset_edits.changed_to", value: number_to_currency(dataset_edit.value, precision: 2, unit: ''))
+                .by
+                  = "#{dataset_edit.creator}, #{I18n.l dataset_edit.created_at, format: :short}"
 
-              .content
-                .reason
-                  = simple_format dataset_edit.commit.message
 
-                - if dataset_edit.commit.source
-                  .source
-                    = link_to I18n.t("dataset_edits.download_source"), dataset_edit.commit.source.source_file.url, class: "button"
+              .reason
+                = simple_format dataset_edit.commit.message
 
-              .clear
+              - if dataset_edit.commit.source
+                .source
+                  = link_to I18n.t("dataset_edits.download_source"), dataset_edit.commit.source.source_file.url, class: "button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,4 @@ en:
   time:
     formats:
       simple: "%Y-%m-%d:%H:%M"
+      short: "%d %B %Y"

--- a/config/locales/en_headers.yml
+++ b/config/locales/en_headers.yml
@@ -2,9 +2,9 @@ en:
   dataset_edits:
     changed_attributes: 'You changed the following attributes:'
     changed_by: "by %{user}"
-    changed_to: "Changed value to %{value}"
+    changed_to: "Changed to %{value}"
     download_source: "Download source"
-    history: History
+    history: Version history
     no_history: No history available for this attribute
     reason_changes: "Reason for change(s)"
     success: "Succesfully updated dataset %{dataset}"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -12,4 +12,4 @@ nl:
   time:
     formats:
       simple: "%Y-%m-%d:%H:%M"
-      short: "%d-%m-%Y"
+      short: "%d %B %Y"

--- a/config/locales/nl_headers.yml
+++ b/config/locales/nl_headers.yml
@@ -2,9 +2,9 @@ nl:
   dataset_edits:
     changed_attributes: 'Je hebt de volgende attributen gewijzigd:'
     changed_by: "door %{user}"
-    changed_to: "Waarde gewijzigd naar %{value}"
+    changed_to: "Gewijzigd naar %{value}"
     download_source: "Download bron"
-    history: Geschiedenis
+    history: Versiegeschiedenis
     no_history: Geen geschiedenis beschikbaar voor deze waarde
     reason_changes: "Reden voor verandering(en)"
     success: "Succesvol %{key} naar %{value} veranderd"

--- a/spec/models/dataset_edit_spec.rb
+++ b/spec/models/dataset_edit_spec.rb
@@ -1,26 +1,45 @@
 require 'rails_helper'
 
 describe DatasetEdit do
-  before { dataset.valid? }
+  before { dataset_edit.valid? }
 
   describe "blank dataset edit" do
-    let(:dataset) { DatasetEdit.new }
+    let(:dataset_edit) { DatasetEdit.new }
 
     it "can't have a blank value" do
-      expect(dataset).to have(1).errors_on(:value)
+      expect(dataset_edit).to have(1).errors_on(:value)
     end
 
     it "can't have a blank key" do
-      expect(dataset).to have(1).errors_on(:key)
+      expect(dataset_edit).to have(1).errors_on(:key)
     end
   end
 
   describe "must be bigger than or 0" do
     describe "for regular attribute" do
-      let(:dataset) { DatasetEdit.new(value: 0) }
+      let(:dataset_edit) { DatasetEdit.new(value: 0) }
 
       it "is invalid" do
-        expect(dataset).to have(0).errors_on(:value)
+        expect(dataset_edit).to have(0).errors_on(:value)
+      end
+    end
+  end
+
+  describe '#creator' do
+    let(:dataset_edit) { DatasetEdit.new(value: 0, commit: commit) }
+    let(:commit) { FactoryBot.create(:commit, user: user) }
+
+    context 'with a creator without a group' do
+      let(:user) { FactoryBot.create(:user, group: nil) }
+      it 'is the users name' do
+        expect(dataset_edit.creator).to eq(user.name)
+      end
+    end
+
+    context 'with a creator without a group' do
+      let(:user) { FactoryBot.create(:user) }
+      it 'is the users name' do
+        expect(dataset_edit.creator).to eq(user.group.key.humanize)
       end
     end
   end


### PR DESCRIPTION
A restyle of the version history as requested in #284.

How it was:

![Screenshot 2021-04-19 at 17 13 26](https://user-images.githubusercontent.com/14875123/115259893-937fe000-a132-11eb-956f-3e055ae173c1.png)

How it is now:

![Screenshot 2021-04-19 at 17 06 43](https://user-images.githubusercontent.com/14875123/115259019-caa1c180-a131-11eb-9ab5-4ecb46961c99.png)

The part that says how the value changed is now enlarged and in a more prominent place. 
If the user that changed the value belongs to a group (like Quintel) this group is shown. So no more changes by Robot.

Closes #284 