### PR TITLE
Add oil mix sliders

### DIFF
--- a/config/interface_elements/agriculture/agriculture_energy_demand.yml
+++ b/config/interface_elements/agriculture/agriculture_energy_demand.yml
@@ -10,7 +10,28 @@ groups:
         unit: 'TJ'
       - key: agriculture_final_demand_wood_pellets_demand
         unit: 'TJ'
-      - key: agriculture_final_demand_crude_oil_demand
+        # this one should have 'input_' in front, in order for theh etsource spec to succeed
+        # should also create / add this key-change to the migration
+      - key: input_agriculture_final_demand_crude_oil_demand
         unit: 'TJ'
       - key: agriculture_final_demand_hydrogen_demand
         unit: 'TJ'
+  - header: agriculture_final_demand_crude_oil_input
+    type: slider
+    items:
+    - key: input_percentage_of_diesel_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_biodiesel_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_kerosene_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_kerosene_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_lpg_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_oil_agriculture_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_crude_oil_agriculture_final_demand_crude_oil
+      unit: '%'
+      flexible: true
+      skip_validation: true

--- a/config/interface_elements/buildings/buildings_energy_demand.yml
+++ b/config/interface_elements/buildings/buildings_energy_demand.yml
@@ -12,5 +12,24 @@ groups:
       unit: 'TJ'
     - key: buildings_final_demand_coal_demand
       unit: 'TJ'
-    - key: buildings_final_demand_crude_oil_demand
+    - key: input_buildings_final_demand_crude_oil_demand
       unit: 'TJ'
+  - header: buildings_final_demand_crude_oil_input
+    type: slider
+    items:
+    - key: input_percentage_of_diesel_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_biodiesel_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_kerosene_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_kerosene_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_lpg_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_oil_buildings_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_crude_oil_buildings_final_demand_crude_oil
+      unit: '%'
+      flexible: true
+      skip_validation: true

--- a/config/interface_elements/households/households_energy_demand.yml
+++ b/config/interface_elements/households/households_energy_demand.yml
@@ -12,7 +12,7 @@ groups:
       unit: 'TJ'
     - key: households_final_demand_coal_demand
       unit: 'TJ'
-    - key: households_final_demand_crude_oil_demand
+    - key: input_households_final_demand_crude_oil_demand
       unit: 'TJ'
   - header: households_final_demand_crude_oil_input
     type: slider

--- a/config/interface_elements/households/households_energy_demand.yml
+++ b/config/interface_elements/households/households_energy_demand.yml
@@ -25,6 +25,8 @@ groups:
       unit: '%'
     - key: input_percentage_of_bio_kerosene_households_final_demand_crude_oil
       unit: '%'
+    - key: input_percentage_of_lpg_households_final_demand_crude_oil
+      unit: '%'
     - key: input_percentage_of_bio_oil_households_final_demand_crude_oil
       unit: '%'
     - key: input_percentage_of_crude_oil_households_final_demand_crude_oil

--- a/config/interface_elements/households/households_energy_demand.yml
+++ b/config/interface_elements/households/households_energy_demand.yml
@@ -14,3 +14,20 @@ groups:
       unit: 'TJ'
     - key: households_final_demand_crude_oil_demand
       unit: 'TJ'
+  - header: households_final_demand_crude_oil_input
+    type: slider
+    items:
+    - key: input_percentage_of_diesel_households_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_biodiesel_households_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_kerosene_households_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_kerosene_households_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_oil_households_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_crude_oil_households_final_demand_crude_oil
+      unit: '%'
+      flexible: true
+      skip_validation: true

--- a/config/interface_elements/industry/industry_heat_chp.yml
+++ b/config/interface_elements/industry/industry_heat_chp.yml
@@ -32,3 +32,23 @@ groups:
       - key: input_share_mixer_gas_fuel_network_gas
         unit: '%'
         flexible: true
+
+  - header: industry_final_demand_crude_oil_input
+    type: slider
+    items:
+    - key: input_percentage_of_diesel_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_biodiesel_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_kerosene_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_kerosene_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_lpg_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_bio_oil_industry_final_demand_crude_oil
+      unit: '%'
+    - key: input_percentage_of_crude_oil_industry_final_demand_crude_oil
+      unit: '%'
+      flexible: true
+      skip_validation: true

--- a/config/locales/en_descriptions.yml
+++ b/config/locales/en_descriptions.yml
@@ -195,6 +195,9 @@ en:
         The pipe lengths of district heating are used to make a good cost estimate for the heat networks. Have a look at our
         <a target="_blank" href="https://docs.energytransitionmodel.com/main/heat-infrastructure-costs">documentation</a>
         for more information on this cost calculation.
+      agriculture_final_demand_crude_oil_input: |
+        The composition below describes the different types of oil that fuel oil-fired heaters. Each percentage describes
+        the share of this oil type in the total oil demand.
       households_final_demand_crude_oil_input: |
         Describes the mix of different oil types used in heating for households.
       households_housing_stock_distribution: |
@@ -263,9 +266,15 @@ en:
       buildings_electricity_cooling_distribution: |
         Below you can see what percentage of total electricity demand for cooling is used by
         these different cooling technologies.
+      buildings_final_demand_crude_oil_input: |
+        The composition below describes the different types of oil that fuel oil-fired heaters. Each percentage describes
+        the share of this oil type in the total oil demand.
       industry_gas_fuelmix: |
         The percentages below indicate the composition of the fuel used in gas-fired CHPs. In some cases
         oil or bio-oil is blended with natural gas.
+      industry_final_demand_crude_oil_input: |
+        The composition below describes the different types of oil that fuel oil-fired heaters. Each percentage describes
+        the share of this oil type in the total oil demand.
       industry_heat: |
         Below you can see how much fuel has been used per CHP type and central heating boiler. The heat produced is supplied
         to industrial sectors with a demand for (central) heat. More information about the various plant types can be found in the

--- a/config/locales/en_descriptions.yml
+++ b/config/locales/en_descriptions.yml
@@ -195,6 +195,8 @@ en:
         The pipe lengths of district heating are used to make a good cost estimate for the heat networks. Have a look at our
         <a target="_blank" href="https://docs.energytransitionmodel.com/main/heat-infrastructure-costs">documentation</a>
         for more information on this cost calculation.
+      households_final_demand_crude_oil_input: |
+        Describes the mix of different oil types used in heating for households.
       households_housing_stock_distribution: |
         Below you can see the breakdown of housing types in your region.
       households_insulation: |

--- a/config/locales/en_headers.yml
+++ b/config/locales/en_headers.yml
@@ -44,6 +44,7 @@ en:
       households_steam_hot_water_distribution: Heat distribution
       households_wood_pellets_distribution: Biomass distribution
       households_crude_oil_distribution: Oil distribution
+      households_final_demand_crude_oil_input: Mix of oil types
       households_coal_distribution: Coal distribution
       households_network_gas_space_heating_hot_water_distribution: Space heating and hot water technologies - gas
       households_electricity_space_heating_hot_water_distribution: Space heating and hot water technologies - electricity

--- a/config/locales/en_headers.yml
+++ b/config/locales/en_headers.yml
@@ -62,6 +62,7 @@ en:
       buildings_wood_pellets_distribution: Biomass distribution
       buildings_crude_oil_distribution: Oil distribution
       buildings_coal_distribution: Coal distribution
+      buildings_final_demand_crude_oil_input: Fuel for oil-fired heaters
       buildings_network_gas_space_heating_distribution: Space heating technologies - gas
       buildings_electricity_space_heating_distribution: Space heating technologies - electricity
       buildings_electricity_lighting_distribution: Lighting technologies - electricity
@@ -84,10 +85,12 @@ en:
 
       # agriculture
       agriculture_final_demand: Final demand
+      agriculture_final_demand_crude_oil_input: Fuel for oil-fired heaters
 
       # industry
       industry_heat: Fuel input for CHP
       industry_gas_fuelmix: Fuel for gas-fired CHPs
+      industry_final_demand_crude_oil_input: Fuel for oil-fired heaters in all industry sectors
       industry_metal_steel: Steel
       industry_metal_aluminium: Aluminium
       industry_metal_other: Other metal industry

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -173,6 +173,7 @@ en:
         input_percentage_of_diesel_households_final_demand_crude_oil: Diesel
         input_percentage_of_biodiesel_households_final_demand_crude_oil: Biodiesel
         input_percentage_of_kerosene_households_final_demand_crude_oil: Kerosene
+        input_percentage_of_lpg_households_final_demand_crude_oil: LPG
         input_percentage_of_bio_kerosene_households_final_demand_crude_oil: Bio kerosene
         input_percentage_of_bio_oil_households_final_demand_crude_oil: Other bio oil
         input_percentage_of_crude_oil_households_final_demand_crude_oil: Other oil

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -170,7 +170,12 @@ en:
         households_final_demand_electricity_households_final_demand_for_lighting_electricity_parent_share: Lighting
         households_final_demand_electricity_households_final_demand_for_space_heating_electricity_parent_share: Space heating
 
-
+        input_percentage_of_diesel_households_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_households_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_households_final_demand_crude_oil: Kerosene
+        input_percentage_of_bio_kerosene_households_final_demand_crude_oil: Bio kerosene
+        input_percentage_of_bio_oil_households_final_demand_crude_oil: Other bio oil
+        input_percentage_of_crude_oil_households_final_demand_crude_oil: Other oil
 
         #buildings
         number_of_buildings: Number of buildings

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -94,7 +94,7 @@ en:
         households_final_demand_network_gas_demand: Gas
         households_final_demand_steam_hot_water_demand: Heat
         households_final_demand_wood_pellets_demand: Solid biomass
-        households_final_demand_crude_oil_demand: Oil
+        input_households_final_demand_crude_oil_demand: Oil
         households_final_demand_coal_demand: Coal
 
         input_households_apartments_heat_demand_reduction: Apartement
@@ -187,8 +187,16 @@ en:
         buildings_final_demand_steam_hot_water_demand: Heat
         buildings_final_demand_wood_pellets_demand: Solid biomass
         buildings_final_demand_coal_demand: Coal
-        buildings_final_demand_crude_oil_demand: Oil
+        input_buildings_final_demand_crude_oil_demand: Oil
         input_buildings_heat_demand_reduction: Heat demand reduction
+
+        input_percentage_of_diesel_buildings_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_buildings_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_buildings_final_demand_crude_oil: Kerosene
+        input_percentage_of_lpg_buildings_final_demand_crude_oil: LPG
+        input_percentage_of_bio_kerosene_buildings_final_demand_crude_oil: Bio kerosene
+        input_percentage_of_bio_oil_buildings_final_demand_crude_oil: Other bio oil
+        input_percentage_of_crude_oil_buildings_final_demand_crude_oil: Other oil
 
         input_buildings_solar_pv_demand: Solar PV production
         buildings_final_demand_solar_thermal_demand: Solar thermal production
@@ -293,8 +301,16 @@ en:
         agriculture_final_demand_network_gas_demand: Gas
         agriculture_final_demand_steam_hot_water_demand: Heat
         agriculture_final_demand_wood_pellets_demand: Solid biomass
-        agriculture_final_demand_crude_oil_demand: Oil
+        input_agriculture_final_demand_crude_oil_demand: Oil
         agriculture_final_demand_hydrogen_demand: Hydrogen
+
+        input_percentage_of_diesel_agriculture_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_agriculture_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_agriculture_final_demand_crude_oil: Kerosene
+        input_percentage_of_lpg_agriculture_final_demand_crude_oil: LPG
+        input_percentage_of_bio_kerosene_agriculture_final_demand_crude_oil: Bio kerosene
+        input_percentage_of_bio_oil_agriculture_final_demand_crude_oil: Other bio oil
+        input_percentage_of_crude_oil_agriculture_final_demand_crude_oil: Other oil
 
         # industry
         industry_chp_combined_cycle_gas_power_fuelmix_demand: Gas CHP
@@ -310,6 +326,14 @@ en:
         input_share_mixer_gas_fuel_network_gas: Gas
         input_share_mixer_gas_fuel_oil: Oil
         input_share_mixer_gas_fuel_bio_oil: Bio oil
+
+        input_percentage_of_diesel_industry_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_industry_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_industry_final_demand_crude_oil: Kerosene
+        input_percentage_of_lpg_industry_final_demand_crude_oil: LPG
+        input_percentage_of_bio_kerosene_industry_final_demand_crude_oil: Bio kerosene
+        input_percentage_of_bio_oil_industry_final_demand_crude_oil: Other bio oil
+        input_percentage_of_crude_oil_industry_final_demand_crude_oil: Other oil
 
         input_industry_metal_steel_scaling_factor: "% national steel industry"
         input_industry_metal_aluminium_scaling_factor: "% national aluminium industry"

--- a/config/locales/nl_descriptions.yml
+++ b/config/locales/nl_descriptions.yml
@@ -197,6 +197,9 @@ nl:
         De leidinglengtes van warmtenetten worden gebruikt om een goede kosteninschatting te maken voor de warmtenetten. Kijk op
         onze <a target="_blank" href="https://docs.energytransitionmodel.com/main/heat-infrastructure-costs">documentatie</a>
         voor meer informatie hierover.
+      agriculture_final_demand_crude_oil_input: |
+        De samenstelling hieronder beschrijft de aandelen van verschillende olietypes die gebruikt worden in olieketels.
+        Ieder percentage staat voor het aandeel van dit type olie in het totale olieverbruik.
       households_final_demand_crude_oil_input: |
         Beschrijft de mix van verschillende olietypes die gebruikt worden voor onder andere verwarming
         in huishoudens.
@@ -256,9 +259,15 @@ nl:
         Hieronder zie je welk percentage van de totale elektriciteitsvraag voor verlichting gebruikt wordt door deze verschillende lampen.
       buildings_electricity_cooling_distribution: |
         Hieronder zie je welk percentage van de totale elektriciteitsvraag voor koelen gebruikt wordt door deze verschillende koelapparaten.
+      buildings_final_demand_crude_oil_input: |
+        De samenstelling hieronder beschrijft de aandelen van verschillende olietypes die gebruikt worden in olieketels.
+        Ieder percentage staat voor het aandeel van dit type olie in het totale olieverbruik.
       industry_gas_fuelmix: |
         Onderstaande percentages geven de samenstelling van de gebruikte brandstof van gasgestookte WKK's weer. In sommige gevallen
         wordt aardolie of bio-olie bijgemengd met aardgas.
+      industry_final_demand_crude_oil_input: |
+        De samenstelling hieronder beschrijft de aandelen van verschillende olietypes die gebruikt worden in olieketels.
+        Ieder percentage staat voor het aandeel van dit type olie in het totale olieverbruik.
       industry_heat: |
         Hieronder staat per WKK-type en centrale verwarmingsketel aangegeven hoeveel brandstof er is gebruikt. De geproduceerde warmte
         wordt geleverd aan industriële sectoren met een vraag naar (centrale) warmte. Meer informatie over de verschillende type ketels kun je vinden in het

--- a/config/locales/nl_descriptions.yml
+++ b/config/locales/nl_descriptions.yml
@@ -197,6 +197,9 @@ nl:
         De leidinglengtes van warmtenetten worden gebruikt om een goede kosteninschatting te maken voor de warmtenetten. Kijk op
         onze <a target="_blank" href="https://docs.energytransitionmodel.com/main/heat-infrastructure-costs">documentatie</a>
         voor meer informatie hierover.
+      households_final_demand_crude_oil_input: |
+        Beschrijft de mix van verschillende olietypes die gebruikt worden voor onder andere verwarming
+        in huishoudens.
       households_housing_stock_distribution: |
         Hieronder zie je de verdeling van huistypen in jouw regio.
       households_insulation: |

--- a/config/locales/nl_headers.yml
+++ b/config/locales/nl_headers.yml
@@ -44,7 +44,7 @@ nl:
       households_steam_hot_water_distribution: Verdeling warmte
       households_wood_pellets_distribution: Verdeling biomassa
       households_crude_oil_distribution: Verdeling olie
-      households_final_demand_crude_oil_input: Verdeling olietypes
+      households_final_demand_crude_oil_input: Samenstelling olie
       households_coal_distribution: Verdeling kolen
       households_network_gas_space_heating_hot_water_distribution: Ruimteverwarming en warm water - gas
       households_electricity_space_heating_hot_water_distribution: Ruimteverwarming en warm water - elektriciteit
@@ -63,6 +63,7 @@ nl:
       buildings_wood_pellets_distribution: Verdeling biomassa
       buildings_crude_oil_distribution: Verdeling olie
       buildings_coal_distribution: Verdeling kolen
+      buildings_final_demand_crude_oil_input: Samenstelling olie
       buildings_network_gas_space_heating_distribution: Ruimteverwarming - gas
       buildings_electricity_space_heating_distribution: Ruimteverwarming - elektriciteit
       buildings_electricity_lighting_distribution: Verlichting - elektriciteit
@@ -85,10 +86,12 @@ nl:
 
       # agriculture
       agriculture_final_demand: Eindgebruik
+      agriculture_final_demand_crude_oil_input: Samenstelling olie
 
       # industry
       industry_heat: Gebruikte brandstof voor WKK en ketels
       industry_gas_fuelmix: Brandstofmix gasgestookte WKK
+      industry_final_demand_crude_oil_input: Brandstoffen voor olieketels in alle industriesectoren
       industry_metal_steel: Staal
       industry_metal_aluminium: Aluminium
       industry_metal_other: Overige metaalindustrie

--- a/config/locales/nl_headers.yml
+++ b/config/locales/nl_headers.yml
@@ -44,6 +44,7 @@ nl:
       households_steam_hot_water_distribution: Verdeling warmte
       households_wood_pellets_distribution: Verdeling biomassa
       households_crude_oil_distribution: Verdeling olie
+      households_final_demand_crude_oil_input: Verdeling olietypes
       households_coal_distribution: Verdeling kolen
       households_network_gas_space_heating_hot_water_distribution: Ruimteverwarming en warm water - gas
       households_electricity_space_heating_hot_water_distribution: Ruimteverwarming en warm water - elektriciteit

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -175,7 +175,12 @@ nl:
         households_final_demand_electricity_households_final_demand_for_lighting_electricity_parent_share: Verlichting
         households_final_demand_electricity_households_final_demand_for_space_heating_electricity_parent_share: Ruimteverwarming
 
-
+        input_percentage_of_diesel_households_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_households_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_households_final_demand_crude_oil: Kerosine
+        input_percentage_of_bio_kerosene_households_final_demand_crude_oil: Bio-kerosine
+        input_percentage_of_bio_oil_households_final_demand_crude_oil: Andere bio-olie
+        input_percentage_of_crude_oil_households_final_demand_crude_oil: Andere olie
 
         #buildings
         number_of_buildings: Aantal gebouwen

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -99,7 +99,7 @@ nl:
         households_final_demand_network_gas_demand: Gas
         households_final_demand_steam_hot_water_demand: Warmte
         households_final_demand_wood_pellets_demand: Vaste biomassa
-        households_final_demand_crude_oil_demand: Olie
+        input_households_final_demand_crude_oil_demand: Olie
         households_final_demand_coal_demand: Kolen
 
         input_households_apartments_heat_demand_reduction: Appartement
@@ -192,8 +192,16 @@ nl:
         buildings_final_demand_steam_hot_water_demand: Warmte
         buildings_final_demand_wood_pellets_demand: Vaste biomassa
         buildings_final_demand_coal_demand: Kolen
-        buildings_final_demand_crude_oil_demand: Olie
+        input_buildings_final_demand_crude_oil_demand: Olie
         input_buildings_heat_demand_reduction: Warmtevraagreductie
+
+        input_percentage_of_diesel_buildings_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_buildings_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_buildings_final_demand_crude_oil: Kerosine
+        input_percentage_of_bio_kerosene_buildings_final_demand_crude_oil: Bio-kerosine
+        input_percentage_of_lpg_buildings_final_demand_crude_oil: LPG
+        input_percentage_of_bio_oil_buildings_final_demand_crude_oil: Andere bio-olie
+        input_percentage_of_crude_oil_buildings_final_demand_crude_oil: Andere olie
 
         input_buildings_solar_pv_demand: Zon-PV-productie
         buildings_final_demand_solar_thermal_demand: Zonthermieproductie
@@ -298,8 +306,16 @@ nl:
         agriculture_final_demand_network_gas_demand: Gas (ex WKK)
         agriculture_final_demand_steam_hot_water_demand: Warmte
         agriculture_final_demand_wood_pellets_demand: Biomassa (ex WKK)
-        agriculture_final_demand_crude_oil_demand: Olie
+        input_agriculture_final_demand_crude_oil_demand: Olie
         agriculture_final_demand_hydrogen_demand: Waterstof
+
+        input_percentage_of_diesel_agriculture_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_agriculture_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_agriculture_final_demand_crude_oil: Kerosine
+        input_percentage_of_bio_kerosene_agriculture_final_demand_crude_oil: Bio-kerosine
+        input_percentage_of_lpg_agriculture_final_demand_crude_oil: LPG
+        input_percentage_of_bio_oil_agriculture_final_demand_crude_oil: Andere bio-olie
+        input_percentage_of_crude_oil_agriculture_final_demand_crude_oil: Andere olie
 
         # industry
         industry_chp_combined_cycle_gas_power_fuelmix_demand: Gas WKK
@@ -315,6 +331,14 @@ nl:
         input_share_mixer_gas_fuel_network_gas: Gas
         input_share_mixer_gas_fuel_oil: Olie
         input_share_mixer_gas_fuel_bio_oil: Bio-olie
+
+        input_percentage_of_diesel_industry_final_demand_crude_oil: Diesel
+        input_percentage_of_biodiesel_industry_final_demand_crude_oil: Biodiesel
+        input_percentage_of_kerosene_industry_final_demand_crude_oil: Kerosine
+        input_percentage_of_bio_kerosene_industry_final_demand_crude_oil: Bio-kerosine
+        input_percentage_of_lpg_industry_final_demand_crude_oil: LPG
+        input_percentage_of_bio_oil_industry_final_demand_crude_oil: Andere bio-olie
+        input_percentage_of_crude_oil_industry_final_demand_crude_oil: Andere olie
 
         input_industry_metal_steel_scaling_factor: "% nationale staalsector"
         input_industry_metal_aluminium_scaling_factor: "% nationale aluminiumsector"

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -179,6 +179,7 @@ nl:
         input_percentage_of_biodiesel_households_final_demand_crude_oil: Biodiesel
         input_percentage_of_kerosene_households_final_demand_crude_oil: Kerosine
         input_percentage_of_bio_kerosene_households_final_demand_crude_oil: Bio-kerosine
+        input_percentage_of_lpg_households_final_demand_crude_oil: LPG
         input_percentage_of_bio_oil_households_final_demand_crude_oil: Andere bio-olie
         input_percentage_of_crude_oil_households_final_demand_crude_oil: Andere olie
 

--- a/db/migrate/20210803161212_add_oil_mix_sliders.rb
+++ b/db/migrate/20210803161212_add_oil_mix_sliders.rb
@@ -1,0 +1,63 @@
+class AddOilMixSliders < ActiveRecord::Migration[5.2]
+  SECTORS = %w[industry households buildings agriculture].freeze
+  OIL_CARRIERS = %w[diesel biodiesel kerosene bio_kerosene lpg bio_oil].freeze
+
+  def up
+    say_with_time('Adding oil mix sliders') do
+      length = Dataset.all.count
+
+      Dataset.find_each.with_index do |dataset, index|
+        # Set input for all oil mixes
+        commit = dataset.commits.build(
+          message: 'Geen data beschikbaar. Nieuwe sliders in het ETM (augustus 2021).',
+          user: User.robot
+        )
+
+        SECTORS.each do |sector|
+          OIL_CARRIERS.each do |carrier|
+            commit.dataset_edits.build(
+              key: "input_percentage_of_#{carrier}_#{sector}_final_demand_crude_oil".to_sym,
+              value: 0.0
+            )
+          end
+          commit.dataset_edits.build(
+            key: "input_percentage_of_crude_oil_#{sector}_final_demand_crude_oil".to_sym,
+            value: 1.0
+          )
+        end
+
+        commit.save!
+
+        say("#{index}/#{length}") if (index % 100).zero?
+      end
+
+      # Rename old sliders
+      SECTORS.each do |sector|
+        next if sector == 'industry'
+
+        DatasetEdit.where(
+          key: "#{sector}_final_demand_crude_oil_demand"
+        ).update_all(
+          key: "input_#{sector}_final_demand_crude_oil_demand"
+        )
+      end
+    end
+  end
+
+  def down
+    say_with_time('Removing oil mix sliders') do
+      SECTORS.each do |sector|
+        OIL_CARRIERS.each do |carrier|
+          DatasetEdit.where(key: "input_percentage_of_#{carrier}_#{sector}_final_demand_crude_oil").delete_all
+        end
+        DatasetEdit.where(key: "input_percentage_of_crude_oil_#{sector}_final_demand_crude_oil").delete_all
+
+        DatasetEdit.where(
+          key: "input_#{sector}_final_demand_crude_oil_demand"
+        ).update_all(
+          key: "#{sector}_final_demand_crude_oil_demand"
+        )
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_124350) do
+ActiveRecord::Schema.define(version: 2021_08_03_161212) do
 
   create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"


### PR DESCRIPTION
Adds sliders to set the oil mix as described in quintel/etmodel#3760 for local datasets. All mixes are set to an initial distribution of:

- 100% _"Other oil"_ (crude oil carrier)
- 0% for all other oil types

Sliders are added to the energy demand tabs of their respecive sectors:

<img width="713" alt="Screenshot 2021-08-03 at 09 59 15" src="https://user-images.githubusercontent.com/14875123/127980222-ac61e003-8c4f-4029-8cd2-81f3dba5913d.png">


---

See also quintel/etsource#2496
And quintel/etmodel#3776


---

Edit: The build will continue to fail on Semaphore unless the ETSource PR is merged, as it is now comparing this branch of ETLocal to the master branch of ETSource which are not compatible.
