### PR TITLE
Update mapping of greengas demand for ENTSO datasets

### DIFF
--- a/config/interface_elements/energy/energy_energy_demand.yml
+++ b/config/interface_elements/energy/energy_energy_demand.yml
@@ -16,8 +16,9 @@ groups:
       - key: energy_distribution_greengas_demand
         unit: 'TJ'
         entso: |
-          EB("Total energy supply", "Biogases") +
-          EB("Transformation input - electricity and heat generation - autoproducer combined heat and power - energy use", "Biogases")
+          EB("Total energy supply", "Biogases") -
+          EB("Transformation input - electricity and heat generation - autoproducer combined heat and power - energy use", "Biogases") -
+          EB("Transformation input - electricity and heat generation - main activity producer combined heat and power - energy use", "Biogases")
       - key: energy_regasification_lng_energy_national_gas_network_natural_gas_demand
         unit: 'TJ'
 

--- a/config/interface_elements/energy/energy_energy_demand.yml
+++ b/config/interface_elements/energy/energy_energy_demand.yml
@@ -16,9 +16,9 @@ groups:
       - key: energy_distribution_greengas_demand
         unit: 'TJ'
         entso: |
-          EB("Total energy supply", "Biogases") -
+          0.995 * (EB("Total energy supply", "Biogases") -
           EB("Transformation input - electricity and heat generation - autoproducer combined heat and power - energy use", "Biogases") -
-          EB("Transformation input - electricity and heat generation - main activity producer combined heat and power - energy use", "Biogases")
+          EB("Transformation input - electricity and heat generation - main activity producer combined heat and power - energy use", "Biogases"))
       - key: energy_regasification_lng_energy_national_gas_network_natural_gas_demand
         unit: 'TJ'
 


### PR DESCRIPTION
The Eurostat energy balance contains the product 'Biogases'. In the CHP script, all the biogas on the transformation input flows for combined heat and power producers (both main activity and autoproducers) are assigned to the local biogas CHP engine (`energy_chp_local_engine`). All the remaining biogas is then assumed to be upgraded to greengas and mixed into the national gas network

In the corresponding [interface_element](https://github.com/quintel/etlocal/blob/production/config/interface_elements/energy/energy_energy_demand.yml) however, instead of subtracting the biogas flows for combined heat and power from the Total energy supply, the transformation input of only the autoproducers was added to get the total greengas demand. This has led to an overestimation of the greengas production in the EU datasets.

The interface_element has been adjusted and the corresponding updated values are exported to ETSource in https://github.com/quintel/etsource/pull/2747

Open to-do's are:

- [x] Check on ETSource whether all the relevant EU datasets are exported (@Charlottevm)
- [x] Check if there are derived datasets that also need to be re-exported (@Charlottevm)
- [x] The biogas upgrade node actually has a loss of 0.5% which is not taken into account when determining the greengas production (@Charlottevm discuss with @mabijkerk how to address this)