### PR TITLE
Add fallback efficiency for EU datasets with efficiencies > 100%

### DIFF
--- a/config/interface_elements/energy/energy_efficiency.yml
+++ b/config/interface_elements/energy/energy_efficiency.yml
@@ -105,7 +105,10 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Large-scale gas plant for district heat (CHP)", "Network gas") > 0.0,
-          -> { EB("Large-scale gas plant for district heat (CHP)", "Heat") / EB("Large-scale gas plant for district heat (CHP)", "Network gas") * 100 },
+          -> { IF(EB("Large-scale gas plant for district heat (CHP)", "Heat") / EB("Large-scale gas plant for district heat (CHP)", "Network gas") * 100 < 100.0,
+               -> { EB("Large-scale gas plant for district heat (CHP)", "Heat") / EB("Large-scale gas plant for district heat (CHP)", "Network gas") * 100 },
+               -> { 42.0 })
+               },
           -> { 42.0 })
       - key: input_energy_chp_local_engine_network_gas_electricity_output_conversion
         unit: '%'
@@ -117,7 +120,10 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Small-scale gas plant for district heat (CHP)", "Network gas") > 0.0,
-          -> { EB("Small-scale gas plant for district heat (CHP)", "Heat") / EB("Small-scale gas plant for district heat (CHP)", "Network gas") * 100 },
+          -> { IF(EB("Small-scale gas plant for district heat (CHP)", "Heat") / EB("Small-scale gas plant for district heat (CHP)", "Network gas") * 100 < 100.0,
+               -> { EB("Small-scale gas plant for district heat (CHP)", "Heat") / EB("Small-scale gas plant for district heat (CHP)", "Network gas") * 100 },
+               -> { 47.0 })
+               },
           -> { 47.0 })
       - key: input_industry_chp_engine_gas_power_fuelmix_electricity_output_conversion
         unit: '%'
@@ -129,7 +135,10 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Gas motor CHP", "Fuelmix") > 0.0,
-          -> { EB("Gas motor CHP", "Heat") / EB("Gas motor CHP", "Fuelmix") * 100 },
+          -> { IF(EB("Gas motor CHP", "Heat") / EB("Gas motor CHP", "Fuelmix") * 100 < 100.0,
+               -> { EB("Gas motor CHP", "Heat") / EB("Gas motor CHP", "Fuelmix") * 100 },
+               -> { 48.0 })
+               },
           -> { 48.0 })
       - key: input_agriculture_chp_engine_network_gas_dispatchable_electricity_output_conversion
         unit: '%'
@@ -153,7 +162,10 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Gas Turbine CHP", "Fuelmix") > 0.0,
-          -> { EB("Gas Turbine CHP", "Heat") / EB("Gas Turbine CHP", "Fuelmix") * 100 },
+          -> { IF(EB("Gas Turbine CHP", "Heat") / EB("Gas Turbine CHP", "Fuelmix") * 100 < 100.0,
+               -> { EB("Gas Turbine CHP", "Heat") / EB("Gas Turbine CHP", "Fuelmix") * 100 },
+               -> { 42.0 })
+               },
           -> { 42.0 })
       - key: input_industry_chp_combined_cycle_gas_power_fuelmix_electricity_output_conversion
         unit: '%'
@@ -165,7 +177,10 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Gas CHP (CCGT)", "Fuelmix") > 0.0,
-          -> { EB("Gas CHP (CCGT)", "Heat") / EB("Gas CHP (CCGT)", "Fuelmix") * 100 },
+          -> { IF(EB("Gas CHP (CCGT)", "Heat") / EB("Gas CHP (CCGT)", "Fuelmix") * 100 < 100.0,
+               -> { EB("Gas CHP (CCGT)", "Heat") / EB("Gas CHP (CCGT)", "Fuelmix") * 100 },
+               -> { 42.0 })
+               },
           -> { 42.0 })
 
   - header: energy_efficiency_other_fossil
@@ -224,14 +239,14 @@ groups:
       - key: input_agriculture_chp_wood_pellets_electricity_output_conversion
         unit: '%'
         entso: |
-          IF(EB("Biogas CHP - agricultural", "Biogases") > 0.0,
-          -> { EB("Biogas CHP - agricultural", "Electricity") / EB("Biogas CHP - agricultural", "Biogases") * 100 },
+          IF(EB("Biogas CHP - agricultural", "Primary solid biofuels") > 0.0,
+          -> { EB("Biogas CHP - agricultural", "Electricity") / EB("Biogas CHP - agricultural", "Primary solid biofuels") * 100 },
           -> { 43.0 })
       - key: input_agriculture_chp_wood_pellets_steam_hot_water_output_conversion
         unit: '%'
         entso: |
-          IF(EB("Biogas CHP - agricultural", "Biogases") > 0.0,
-          -> {EB("Biogas CHP - agricultural", "Heat") / EB("Biogas CHP - agricultural", "Biogases") * 100},
+          IF(EB("Biogas CHP - agricultural", "Primary solid biofuels") > 0.0,
+          -> {EB("Biogas CHP - agricultural", "Heat") / EB("Biogas CHP - agricultural", "Primary solid biofuels") * 100},
           -> { 47.0 })
       - key: input_energy_chp_local_engine_biogas_electricity_output_conversion
         unit: '%'
@@ -243,19 +258,22 @@ groups:
         unit: '%'
         entso: |
           IF(EB("Biogas CHP", "Biogases") > 0.0,
-          -> { EB("Biogas CHP", "Heat") / EB("Biogas CHP", "Biogases") * 100 },
+          -> { IF(EB("Biogas CHP", "Heat") / EB("Biogas CHP", "Biogases") * 100 < 100.0,
+               -> { EB("Biogas CHP", "Heat") / EB("Biogas CHP", "Biogases") * 100 },
+               -> { 47.0 })
+               },
           -> { 47.0 }) 
       - key: input_agriculture_chp_engine_biogas_electricity_output_conversion
         unit: '%'
         entso: |
-          IF(EB("Biomass CHP - agricultural", "Primary solid biofuels") > 0.0,
-          -> { EB("Biomass CHP - agricultural", "Electricity") / EB("Biogas CHP - agricultural", "Primay solid biofuels") * 100 },
+          IF(EB("Biomass CHP - agricultural", "Biogases") > 0.0,
+          -> { EB("Biomass CHP - agricultural", "Electricity") / EB("Biogas CHP - agricultural", "Biogases") * 100 },
           -> { 28.9 })
       - key: input_agriculture_chp_engine_biogas_steam_hot_water_output_conversion
         unit: '%'
         entso: |
-          IF(EB("Biomass CHP - agricultural", "Primary solid biofuels") > 0.0,
-          -> {EB("Biomass CHP - agricultural", "Heat") / EB("Biogas CHP - agricultural", "Primary solid biofuels") * 100},
+          IF(EB("Biomass CHP - agricultural", "Biogases") > 0.0,
+          -> {EB("Biomass CHP - agricultural", "Heat") / EB("Biogas CHP - agricultural", "Biogases") * 100},
           -> { 83.5 })
       - key: input_energy_chp_supercritical_waste_mix_electricity_output_conversion
         unit: '%'


### PR DESCRIPTION
This is a temporary solution for quintel/etdataset#949

If statements are added to CHPs (gas, or gas-based CHPs), that assign a fallback efficiency when the `energy_balance_generator` [script](https://github.com/quintel/etdataset/tree/master/tools/energy_balance_generator) has produced efficiencies > 100%