### PR TITLE
BECCUS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'str_enum'
 gem 'git'
 
 gem 'transformer', ref: 'cb766b1', github: 'quintel/transformer'
-gem 'atlas',       ref: 'd5c84b5', github: 'quintel/atlas'
+gem 'atlas',       ref: 'f9d985c', github: 'quintel/atlas'
 gem 'rubel',       ref: 'ad3d44e', github: 'quintel/rubel'
 gem 'refinery',    ref: '5439199', github: 'quintel/refinery'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: d5c84b505494c92f816624f8b30b4b47941ff75d
-  ref: d5c84b5
+  revision: f9d985c4ee9dbd1617e1cdd22f01441f1e810047
+  ref: f9d985c
   specs:
     atlas (1.0.0)
       activemodel (>= 7)


### PR DESCRIPTION
With this update, the option to model BECC(U)S plants with the ETM becomes possible.

This PR includes:

- Atlas ref update to include new `captured_biogenic_co2_price` area attribute in datasets

This goes with:

- https://github.com/quintel/etmodel/pull/4220
- https://github.com/quintel/etsource/pull/3019
- https://github.com/quintel/etengine/pull/1409
- https://github.com/quintel/etdataset/pull/993