### PR TITLE
Rename datasets

### DIFF
--- a/db/migrate/20240319134606_rename_res_datasets.rb
+++ b/db/migrate/20240319134606_rename_res_datasets.rb
@@ -1,0 +1,19 @@
+class RenameResDatasets < ActiveRecord::Migration[7.0]
+  def change
+    rename = {
+      RES03: 'Regio Drenthe',
+      RES06: 'Regio Friesland',
+      RES11: 'Holland Rijnland',
+      RES13: 'Rotterdam Denhaag',
+      RES20: 'Noord Oost Brabant',
+      RES26: 'Cleantechregio',
+    }
+    
+    
+    rename.each do |geo_id, new_name|
+      regio = Dataset.where(geo_id: geo_id).first!
+      regio.name = new_name
+      regio.save!
+    end
+  end
+end

--- a/db/migrate/20240319151128_rename_efate_dataset.rb
+++ b/db/migrate/20240319151128_rename_efate_dataset.rb
@@ -1,0 +1,14 @@
+class RenameEfateDataset < ActiveRecord::Migration[7.0]
+  def change
+    rename = {
+      NH5: 'VUNH5'
+    }
+    
+    
+    rename.each do |geo_id, new_geo_id|
+      regio = Dataset.where(geo_id: geo_id).first!
+      regio.geo_id = new_geo_id
+      regio.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_23_114314) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_134606) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"
     t.integer "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_134606) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_151128) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"
     t.integer "user_id"


### PR DESCRIPTION
This PR fixes wrongly renamed RES regions datasets, to be in line with ETSource again. This PR also fixes the geo_id of Efate, to be in line with ETSource again.