### PR TITLE
Migration for greengas shares key name change

### DIFF
--- a/config/interface_elements/energy/energy_biomass.yml
+++ b/config/interface_elements/energy/energy_biomass.yml
@@ -6,11 +6,11 @@ groups:
       weighted_average:
         - energy_distribution_greengas_demand
     items:
-      - key: energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share
+      - key: energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share
         unit: '%'
-      - key: energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share
+      - key: energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share
         unit: '%'
-      - key: energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share
+      - key: energy_greengas_upgrade_biogas_energy_greengas_production_child_share
         unit: '%'
         flexible: true
 

--- a/config/locales/descriptions_interface_items/en_energy.yml
+++ b/config/locales/descriptions_interface_items/en_energy.yml
@@ -7,11 +7,11 @@ en:
         Grid losses due to transmission and distribution of electricity in this region. On average, this is around 5-8% of total electricity demand.
       energy_distribution_greengas_demand: |
         The amount of green gas blended into the gas network. This excludes direct use of biogas (for example local production used as CHP fuel).
-      energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share: |
+      energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share: |
         What share of the current green gas demand in this area is produced by gasification of dry biomass?
-      energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share: |
+      energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share: |
         What share of the current green gas demand in this area is produced by gasification of wet biomass?
-      energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share: |
+      energy_greengas_upgrade_biogas_energy_greengas_production_child_share: |
         What share of the current green gas demand in this area is produced by fermentation of biomass?
       energy_distribution_biogenic_waste_energy_distribution_waste_mix_child_share: |
         This setting is only relevant if a waste-to-energy plant is present in this area. This

--- a/config/locales/descriptions_interface_items/nl_energy.yml
+++ b/config/locales/descriptions_interface_items/nl_energy.yml
@@ -9,13 +9,13 @@ nl:
       energy_distribution_greengas_demand: |
         De hoeveelheid groen gas die is bijgemengd in het gasnet. Direct gebruik van biogas (bijvoorbeeld lokale
         productie die wordt verbrand in een WKK) valt hier niet onder.
-      energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share: |
+      energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share: |
         Hoeveel procent van de huidige groengasproductie in deze regio gebeurt door middel van
         vergassing van droge biomassa?
-      energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share: |
+      energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share: |
         Hoeveel procent van de huidige groengasproductie in deze regio gebeurt door middel van
         vergassing van natte biomassa?
-      energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share: |
+      energy_greengas_upgrade_biogas_energy_greengas_production_child_share: |
         Hoeveel procent van de huidige groengasproductie in deze regio gebeurt door middel van
         vergisting van biomassa?
       energy_distribution_biogenic_waste_energy_distribution_waste_mix_child_share: |

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -609,9 +609,9 @@ en:
         energy_distribution_network_gas_loss_demand: Network losses
         energy_distribution_crude_oil_loss_demand: Network losses
 
-        energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share: Dry gasification
-        energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share: Wet gasification
-        energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share: Fermentation
+        energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share: Dry gasification
+        energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share: Wet gasification
+        energy_greengas_upgrade_biogas_energy_greengas_production_child_share: Fermentation
 
         energy_distribution_biogenic_waste_energy_distribution_waste_mix_child_share: Biogenic
         energy_distribution_non_biogenic_waste_energy_distribution_waste_mix_child_share: Non-biogenic

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -614,9 +614,9 @@ nl:
         energy_distribution_network_gas_loss_demand: Netverliezen
         energy_distribution_crude_oil_loss_demand: Netverliezen
 
-        energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share: Droge vergassing
-        energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share: Natte vergassing
-        energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share: Vergisting
+        energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share: Droge vergassing
+        energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share: Natte vergassing
+        energy_greengas_upgrade_biogas_energy_greengas_production_child_share: Vergisting
 
         energy_distribution_biogenic_waste_energy_distribution_waste_mix_child_share: Biogeen
         energy_distribution_non_biogenic_waste_energy_distribution_waste_mix_child_share: Niet-biogeen

--- a/db/migrate/20240628083308_rename_greengas_keys.rb
+++ b/db/migrate/20240628083308_rename_greengas_keys.rb
@@ -1,0 +1,21 @@
+class RenameGreengasKeys < ActiveRecord::Migration[7.0]
+  
+  # old_key => new_key
+  KEYS = {
+    'energy_greengas_gasification_dry_biomass_energy_distribution_greengas_child_share' => 'energy_greengas_gasification_dry_biomass_energy_greengas_production_child_share',
+    'energy_greengas_gasification_wet_biomass_energy_distribution_greengas_child_share' => 'energy_greengas_gasification_wet_biomass_energy_greengas_production_child_share',
+    'energy_greengas_upgrade_biogas_energy_distribution_greengas_child_share' => 'energy_greengas_upgrade_biogas_energy_greengas_production_child_share'
+  }.freeze
+
+  def self.up
+    # First grab the DatasetEdits that contain a change for the 'old' keys
+    # to shrink the pool of datasets to search in below
+    dataset_edits = DatasetEdit.where(key: KEYS.keys)
+
+    # Replace all the old keys with the new keys, in batches
+    KEYS.each do |old_key, new_key|
+      dataset_edits.where(key: old_key).in_batches { |batch| batch.update_all(key: new_key) }
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_14_122958) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_28_083308) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"
     t.integer "user_id"


### PR DESCRIPTION
As part of https://github.com/quintel/etsource/pull/3076#issuecomment-2194840560 the key names of greengas shares are changed. 