### PR TITLE
Fixes locales of Norway and other areas

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,11 +125,12 @@ en:
     se: Sweden
     sg: Singapore
     si: Slovenia
-    no: Norway
+    "no": Norway          # Quotation marks required, otherwise no is read as a boolean False
     rs: Serbia
     ch: Switzerland
     gb: Great Britain
     any: All countries
+    eu: Other areas       # Represents non-countries with eu as parent dataet
 
   groups:
     country: Countries

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -32,7 +32,7 @@ nl:
     dk: Denemarken
     es: Spanje
     ee: Estland
-    eu: Europese Unie (27 landen)
+    eu27: Europese Unie (27 landen)
     fi: Finland
     fr: Frankrijk
     el: Griekenland
@@ -50,11 +50,12 @@ nl:
     se: Zweden
     si: Slovenië
     sg: Singapore
-    no: Noorwegen
+    "no": Noorwegen           # Quotation marks required, otherwise no is read as a boolean False
     rs: Servië
     ch: Zwitserland
     gb: Groot-Brittannië
     any: Alle landen
+    eu: Overige gebieden      # Represents non-countries with eu as parent dataet
 
   groups:
     country: Landen


### PR DESCRIPTION
This PR fixes:

- Locales of Norway: quotation marks needed in translations
- Locales of other areas: which have eu as parent dataset

Issues (that are now fixed):
![image](https://github.com/user-attachments/assets/afa9a720-d232-4623-8f2f-39b72ca71b57)
