### PR TITLE
Energy balance README and update key descriptions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,17 +13,16 @@ en:
   inherited_file: This file is inherited from the %{parent} dataset.
   data_source_messages:
     entso:
-      default: Value sourced from the Eurostat energy balance.
-      view_file: View energy balance
+      default: Value sourced from the country's energy balance.
       industry_ICT: |
-        Value sourced from the Eurostat energy balance.
+        Value sourced from the country's energy balance.
 
         ICT sector demand is included in the 'final consumption - other sectors - commercial and public services' on the energy balance, but there is no explicit flow.
         An estimate of this demand is therefore made.
 
         This demand is then moved in <a href="https://github.com/quintel/etdataset-public/blob/master/tools/energy_balance_generator/etm_tools/energy_balance_operations/converters/industry_ict.py" target=\"_blank\"> this script</a> from the commercial and public services to a new sub-sector of the industry, the ICT sector.
       industry_metal: |
-        Value sourced from the Eurostat energy balance.
+        Value sourced from the country's energy balance.
 
         Other metals demand is included in the 'final consumption - industry sector - non-ferrous metals' on the energy balance, but there is no explicit flow.
 
@@ -31,7 +30,7 @@ en:
 
         This aluminium demand is then defined as a sub-category of the non-ferrous demand and the remaining demand is categorized as other metals demand in <a href="https://github.com/quintel/etdataset-public/blob/master/tools/energy_balance_generator/etm_tools/energy_balance_operations/converters/industry_metal.py" target=\"_blank\"> this script</a>.
       industry_aluminium: |
-        Value sourced from the Eurostat energy balance.
+        Value sourced from the country's energy balance.
 
         Aluminium demand is included in the 'final consumption - industry sector - non-ferrous metals' on the energy balance, but there is no explicit flow.
 
@@ -39,7 +38,7 @@ en:
 
         This aluminium demand is then defined as a sub-category of the non-ferrous demand and the remaining demand is categorized as other metals demand in <a href="https://github.com/quintel/etdataset-public/blob/master/tools/energy_balance_generator/etm_tools/energy_balance_operations/converters/industry_metal.py" target=\"_blank\"> this script</a>.
       industry_fertilizer: |
-        Value sourced from the Eurostat energy balance.
+        Value sourced from the country's energy balance.
 
         Fertilizer demand is included in the 'final consumption - industry sector - chemical and petrochemical' on the energy balance, but there is no explicit flow.
 
@@ -47,7 +46,7 @@ en:
 
         This fertilizer demand is then defined as a sub-category of the chemical and petrochemical demand and the remaining demand is categorized as other chemicals demand in <a href="https://github.com/quintel/etdataset-public/blob/master/tools/energy_balance_generator/etm_tools/energy_balance_operations/converters/industry_chemical.py" target=\"_blank\"> this script</a>.
       industry_chemical: |
-        Value sourced from the Eurostat energy balance.
+        Value sourced from the country's energy balance.
 
         Other chemicals demand is included in the 'final consumption - industry sector - chemical and petrochemical' on the energy balance, but there is no explicit flow.
 
@@ -55,27 +54,27 @@ en:
 
         This fertilizer demand is then defined as a sub-category of the chemical and petrochemical demand and the remaining demand is categorized as other chemicals demand in <a href="https://github.com/quintel/etdataset-public/blob/master/tools/energy_balance_generator/etm_tools/energy_balance_operations/converters/industry_chemical.py" target=\"_blank\"> this script</a>.
       energy_fossil_electricity_production: |
-        The total electricity production per energy carrier is sourced from the Eurostat energy balance.
+        The total electricity production per energy carrier is sourced from the country's energy balance.
 
         Since the ETM distinguishes several plant types per energy carrier an additional analysis has been done to calculate the production per plant type. This calculation was done based on power plant capacities provided by TenneT.
 
         These power plants have been added to the "complemented energy balance" that can be found in the link below this message.
 
         Links:
-        - <a href="https://github.com/quintel/etdataset-public/blob/master/eu_datasets/power_plants/20211209_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
+        - <a href="https://github.com/quintel/etdataset-public/blob/master/source_analyses/EU27_european_union/2019/eu_datasets/power_plants/20220609_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
         - <a href="https://github.com/quintel/etdataset-public/tree/master/tools/energy_balance_generator" target="_blank">This GitHub-link</a> brings you to the python scripts that were used to add the power plants to the "complemented energy balance" including their fuel input and production
       energy_renewable_electricity_production: |
-        The total electricity production per energy carrier is sourced from the Eurostat energy balance.
+        The total electricity production per energy carrier is sourced from the country's energy balance.
 
-        Since the ETM distinguishes several plant types per energy carrier an additional analysis has been done to calculate the production per plant type. This calculation was done based on renewable capacities from <a href="https://ec.europa.eu/eurostat/databrowser/bookmark/cb78d4e5-82c0-4874-963f-fb265ae2025f?lang=en&page=time:2019" target="_blank">this Eurostat table</a>.
+        Since the ETM distinguishes several plant types per energy carrier an additional analysis has been done to calculate the production per plant type. This calculation was done based on renewable capacities from <a href="https://ec.europa.eu/country's/databrowser/bookmark/cb78d4e5-82c0-4874-963f-fb265ae2025f?lang=en&page=time:2019" target="_blank">this country's table</a>.
 
         These renewable plants have been added to the "complemented energy balance" that can be found in the link below this message.
 
         Links:
-        - <a href="https://github.com/quintel/etdataset-public/blob/master/eu_datasets/power_plants/20211209_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
+        - <a href="https://github.com/quintel/etdataset-public/blob/master/source_analyses/EU27_european_union/2019/eu_datasets/power_plants/20220609_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
         - <a href="https://github.com/quintel/etdataset-public/tree/master/tools/energy_balance_generator" target="_blank">This GitHub-link</a> brings you to the python scripts that were used to add the renewable plants to the "complemented energy balance" including their fuel input and production
       energy_heat_production: |
-        The total heat production per energy carrier is sourced from the Eurostat energy balance.
+        The total heat production per energy carrier is sourced from the country's energy balance.
 
         A simple analysis has been done to assign the heat production to the district heating technologies available in the ETM, taking into account the heat demand on the two district heating networks that are modelled in het ETM: a residential and industrial heating network.
 
@@ -84,14 +83,14 @@ en:
         Links:
         - <a href="https://github.com/quintel/etdataset-public/tree/master/tools/energy_balance_generator" target="_blank">This GitHub-link</a> brings you to the python scripts that were used to add the heat plants to the "complemented energy balance" including their fuel input and production
       energy_efficiency: |
-        The total electricity and heat production per energy carrier is sourced from the Eurostat energy balance.
+        The total electricity and heat production per energy carrier is sourced from the country's energy balance.
 
         Since the ETM distinguishes several plant types per energy carrier an additional analysis has been done to calculate the production per plant type. This calculation was done based on power plant capacities provided by TenneT.
 
         These power plants have been added to the "complemented energy balance" that can be found in the link below this message. The efficiencies have been calculated by dividing the electricity or heat output by the fuel input from the energy balance. For other power plants default efficiencies are used.
 
         Links:
-        - <a href="https://github.com/quintel/etdataset-public/blob/master/eu_datasets/power_plants/20211209_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
+        - <a href="https://github.com/quintel/etdataset-public/blob/master/source_analyses/EU27_european_union/2019/eu_datasets/power_plants/20220609_EU_power_plants.xlsx" target="_blank">This GitHub-link</a> brings you to the Excel with the calculations
         - <a href="https://github.com/quintel/etdataset-public/tree/master/tools/energy_balance_generator" target="_blank">This GitHub-link</a> brings you to the python scripts that were used to add the power plants to the "complemented energy balance" including their fuel input and production
   countries:
     be: Belgium

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -13,10 +13,7 @@ nl:
   inherited_file: This file is inherited from the %{parent} dataset.
   data_source_messages:
     entso:
-      default: Value sourced from the Eurostat energy balance.
-      view_file: Bekijk de energiebalans
-      # households_energy_demand: 'Deze waarde is een test'
-
+      default: Value sourced from the country's energy balance.
 
   countries:
     be: België

--- a/data/datasets/energy_balance/README.md
+++ b/data/datasets/energy_balance/README.md
@@ -1,0 +1,5 @@
+# Energy balance source
+
+The energy balances in this folder were generated from one of the following sources:
+* Eurostat: the Europe datasets are typically sourced from Eurostat, these datasets are therefore open source
+* IEA: world datasets are typically sourced form IEA, these energy balances are therefore encrypted and saved as .gpg file


### PR DESCRIPTION
This PR:

- Adds a README.md file to the energy_balance folder
- Updates the key descriptions related to energy balance keys where links to the Eurostat EB are removed and old file links are updated with working links

Fixes:
- https://github.com/quintel/etlocal/issues/559
- the first proposed solution of https://github.com/quintel/etlocal/issues/557