### PR TITLE
Retire dataset GM0345HA_Het_Ambacht_Veenendaal

### DIFF
--- a/db/migrate/20250203094009_retire_gm0345ha_het_ambacht_veenendaal.rb
+++ b/db/migrate/20250203094009_retire_gm0345ha_het_ambacht_veenendaal.rb
@@ -1,0 +1,27 @@
+class RetireGm0345haHetAmbachtVeenendaal < ActiveRecord::Migration[7.0]
+
+  # Destroy dataset and save dataset attributes to temporary file for
+  # migration rollback purposes
+  def up
+    dataset = Dataset.find_by(geo_id: 'GM0345HA')
+    save_deleted_datasets([dataset.attributes].to_json) if dataset&.destroy
+  end
+
+  # Functionality for rollback purposes where removed data is restored to the
+  # deleted datasets
+  def down
+    return unless deleted_datasets.any?
+
+    deleted_datasets.each { |attrs| Dataset.create!(attrs.symbolize_keys) }
+  end
+
+  private
+
+  def save_deleted_datasets(deleted_datasets)
+    File.write(Rails.root.join('tmp', 'deleted_datasets.json'), deleted_datasets)
+  end
+
+  def deleted_datasets
+    @deleted_datasets ||= JSON.parse(File.read(Rails.root.join('tmp', 'deleted_datasets.json')))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_10_101108) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_03_094009) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "source_id"
     t.integer "user_id"


### PR DESCRIPTION
Retirement of dataset GM0345HA_Het_Ambacht_Veenendaal, which was a custom dataset generated for a specific project. 

Goes with https://github.com/quintel/etsource/pull/3203