### PR TITLE
Remove duplicate entries for solar thermal in households and buildings

### DIFF
--- a/config/interface_elements/buildings/buildings_energy_demand.yml
+++ b/config/interface_elements/buildings/buildings_energy_demand.yml
@@ -28,10 +28,6 @@ groups:
         unit: 'TJ'
         entso: |
           EB("Final consumption - other sectors - commercial and public services - energy use", "Oil")
-      - key: buildings_final_demand_solar_thermal_demand
-        unit: 'TJ'
-        entso: |
-          EB("Final consumption - other sectors - commercial and public services - energy use", "Solar thermal")
 
   - header: buildings_final_demand_steam_hot_water_input
     type: slider

--- a/config/interface_elements/households/households_energy_demand.yml
+++ b/config/interface_elements/households/households_energy_demand.yml
@@ -28,10 +28,6 @@ groups:
         unit: 'TJ'
         entso: |
           EB("Final consumption - other sectors - households - energy use", "Oil")
-      - key: households_final_demand_solar_thermal_demand
-        unit: 'TJ'
-        entso: |
-          EB("Final consumption - other sectors - households - energy use", "Solar thermal")
 
   - header: households_final_demand_steam_hot_water_input
     type: slider


### PR DESCRIPTION
Removed [solar_thermal_production] from building and household demand to now only show in building and household supply. 