### PR TITLE
Adding amalgamator method for crude oil mixes in industry

### DIFF
--- a/config/interface_elements/industry/industry.yml
+++ b/config/interface_elements/industry/industry.yml
@@ -3,6 +3,17 @@ key: industry
 groups:
   - header: industry_final_demand_crude_oil_input
     type: slider
+    combination_method:
+      weighted_average:
+        - sum:
+          - input_industry_chemical_other_crude_oil_demand
+          - input_industry_chemical_fertilizers_crude_oil_demand
+          - input_industry_food_crude_oil_demand
+          - input_industry_metal_other_crude_oil_demand
+          - input_industry_other_crude_oil_demand
+          - input_industry_paper_crude_oil_demand
+          - input_industry_chemical_refineries_crude_oil_demand
+          - input_industry_metal_steel_crude_oil_demand
     items:
     - key: input_percentage_of_diesel_industry_final_demand_crude_oil
       unit: '%'
@@ -45,6 +56,12 @@ groups:
 
   - header: industry_final_demand_crude_oil_non_energetic_input
     type: slider
+    combination_method:
+      weighted_average:
+        - sum:
+          - input_industry_chemical_other_crude_oil_non_energetic_demand
+          - input_industry_chemical_fertilizers_crude_oil_non_energetic_demand
+          - input_industry_other_crude_oil_non_energetic_demand
     items:
     - key: input_percentage_of_diesel_industry_final_demand_crude_oil_non_energetic
       unit: '%'


### PR DESCRIPTION
This PR adds missing amalgamtor methods for the crude oil mixes in the industry section. 
The new amalgamtor method is a weighted_average method based on the summed final demand of the crude oil mixes in which the respective oil mixes are used. 

@louispt1 Could you check if you agree with this method?