### PR TITLE
Alter EB method for coke oven cokes in steel sector

### DIFF
--- a/config/interface_elements/industry/industry_steel.yml
+++ b/config/interface_elements/industry/industry_steel.yml
@@ -121,11 +121,9 @@ groups:
         unit: '%'
         entso: |
           IF((
-          EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat") +
-          EB("Transformation input - blast furnaces - energy use", "Coke oven coke") ) > 0.0,
+          EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat")) > 0.0,
           -> { EB("Transformation output - blast furnaces", "Coal gas") / (
-          EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat") +
-          EB("Transformation input - blast furnaces - energy use", "Coke oven coke") ) },
+          EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat")) },
           -> { 0.4 })
         combination_method: average
       - key: input_energy_blastfurnace_transformation_loss_output_conversion

--- a/config/interface_elements/industry/industry_steel.yml
+++ b/config/interface_elements/industry/industry_steel.yml
@@ -107,7 +107,8 @@ groups:
       - key: input_energy_blastfurnace_transformation_coal_input_demand
         unit: 'TJ'
         entso: |
-          EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat")
+          (EB("Transformation input - blast furnaces - energy use", "Coal incl lignite and peat") - 
+          EB("Transformation input - blast furnaces - energy use", "Coke oven coke"))
       - key: input_energy_blastfurnace_transformation_cokes_input_demand
         unit: 'TJ'
         entso: |


### PR DESCRIPTION
This PR closes #538 by altering the EB method for the key input_energy_blastfurnace_transformation_coal_input_demand. 

In this alteration the flow of the carrier "coke oven coke" is now subtracted from the carrier group "Coal incl lignite and peat".

I prefered this approach to adding a new carrier group for coal, since we already have 2 carrier groups for Coal. 

Goes together with:
https://github.com/quintel/etsource/pull/3300

Assigned to @mabijkerk for now, reassign at will.