### PR TITLE
Add nl2023 dataset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'config'
 gem 'git'
 
 gem 'transformer', ref: 'cb766b1', github: 'quintel/transformer'
-gem 'atlas',       ref: '58dc99f', github: 'quintel/atlas'
+gem 'atlas',       ref: '267acc8', github: 'quintel/atlas'
 gem 'rubel',       ref: 'ad3d44e', github: 'quintel/rubel'
 gem 'refinery',    ref: '5439199', github: 'quintel/refinery'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 58dc99f61d74aadcb58f7dea6f9bc07c82b91bdd
-  ref: 58dc99f
+  revision: 267acc89ff2c6faf441d017e63a97f657a89b26c
+  ref: 267acc8
   specs:
     atlas (1.0.0)
       activemodel (>= 7)


### PR DESCRIPTION
This PR makes the changes for the addition of nl2023, the dataset for the Netherlands with start year 2023.

Goes with:
- https://github.com/quintel/etmodel/pull/4552
- https://github.com/quintel/etengine/pull/1618
- https://github.com/quintel/etdataset/pull/1043
- https://github.com/quintel/documentation/pull/235
- https://github.com/quintel/etsource/pull/3301
- https://github.com/quintel/atlas/pull/173
- https://github.com/quintel/etlocal/pull/616