### PR TITLE
Revert group to country from parent

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -11,7 +11,7 @@ class Dataset < ApplicationRecord
   validates :parent, presence: true, inclusion: {in: Etsource.available_datasets}
 
   ORDER = %w[
-    parent
+    country
     province
     res
     region
@@ -50,7 +50,7 @@ class Dataset < ApplicationRecord
     elsif geo_id.start_with?('RG')
       'region'
     elsif entso_data_source? || geo_id.start_with?('UKNI') || geo_id.start_with?('GB')
-      'parent'
+      'country'
     elsif geo_id.start_with?('RES', 'ES')
       'res'
     else


### PR DESCRIPTION
This PR reverts the change in group to country from parent. The group is meant to represent the level of the dataset for display purposes in ETModel. Therefore, it makes sense to keep this as 'country' for country level datasets.

I tested the changes with country level datasets that refer to themselves as parent, in which case no changes are exported to ETSource. I also tested a municipal level dataset with a regional dataset as its parent; in that case, the dataset id and parent id change, as well as the base_dataset and scalings. This is the expected behaviour.