### PR TITLE
Fix yarn apt-key deprecation in Dockerfile.production

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -13,8 +13,8 @@ RUN apt-get update -yqq && \
     gnupg \
     nodejs
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarn-archive-keyring.gpg > /dev/null \
+  && echo "deb [signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update && apt-get install -y yarn && rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundler -v '>= 2'


### PR DESCRIPTION
#### Context

Semaphore deploy of master to staging is failing

#### Implemented changes

Replace deprecated apt-key with gpg --dearmor keyring method.
apt-key was removed in Debian 12 (Bookworm), the base for ruby:3.4-slim.

## Checklist

- [ ] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
