### PR TITLE
Fix no data bug on stable

### DIFF
--- a/app/models/editable_attribute.rb
+++ b/app/models/editable_attribute.rb
@@ -36,11 +36,6 @@ class EditableAttribute
   # If a dataset has an edit - give that value. If it doesn't have an edit,
   # fall back to the default value.
   def value
-    # Return nil if there’s no edit befre the freeze date
-    if @freeze_date.present? && latest.nil?
-      return nil
-    end
-
     # If we can query the source (e.g., ENTSO-E), use that value
     if @dataset.queryable_source? && @entso_query.present?
       return @dataset.execute_query(@entso_query)


### PR DESCRIPTION
#### Context
A lot of the derived data values were showing 'no value' due to an aggressive nil check. This quick fix should resolve the bug.

#### Implemented changes
Remove aggressive nil on nothing before freeze date - instead revert to default like usual.

Of course, the default values will also sometimes change from when a stable version is made, but without making full copies of the stable version datasets for the stable versions, there's no simple way around this inheritance issue. Maybe in the future we can get the data out of github for real, and then we can check out a certain etsource tag for stable versions. For now I think this is the simplest solution.

#### Related
Closes #672 

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review