### PR TITLE
Change maintainer label in Dockerfile to info@energytransitionmodel.com

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,10 +24,10 @@ blocks:
             - bundle config set --local deployment 'true'
             - bundle install
             - cache store
-            - git clone git@github.com:quintel/etsource.git --depth 1 tmp/etsource
             - cat /dev/null > config/database.yml
             - bundle exec rails db:setup
             - bundle exec rspec --format RspecJunitFormatter --out /tmp/junit-results/rspec.xml --format progress
+            - git clone git@github.com:quintel/etsource.git --depth 1 tmp/etsource
             - ETSOURCE_PATH=tmp/etsource bundle exec rspec spec/services/etsource_spec.rb --format RspecJunitFormatter --out /tmp/junit-results/etsource.xml --format progress
       epilogue:
         always:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,10 +24,10 @@ blocks:
             - bundle config set --local deployment 'true'
             - bundle install
             - cache store
+            - git clone git@github.com:quintel/etsource.git --depth 1 tmp/etsource
             - cat /dev/null > config/database.yml
             - bundle exec rails db:setup
             - bundle exec rspec --format RspecJunitFormatter --out /tmp/junit-results/rspec.xml --format progress
-            - git clone git@github.com:quintel/etsource.git --depth 1 tmp/etsource
             - ETSOURCE_PATH=tmp/etsource bundle exec rspec spec/services/etsource_spec.rb --format RspecJunitFormatter --out /tmp/junit-results/etsource.xml --format progress
       epilogue:
         always:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:4.0-slim
 
-LABEL maintainer="dev@quintel.com"
+LABEL maintainer="info@energytransitionmodel.com"
 
 RUN apt-get update -yqq && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,6 @@
 FROM ruby:4.0-slim
 
-LABEL maintainer="dev@quintel.com"
+LABEL maintainer="info@energytransitionmodel.com"
 
 RUN apt-get update -yqq && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \


### PR DESCRIPTION
#### Context
Remove dev@quintel from public facing locations, replace with info@energytransitionmodel.com.

The Dockerfile LABEL is only a metadata field, so this change should have no effect on the container itself.
See: https://docs.docker.com/reference/dockerfile/#label

Goes with pull requests ...
[engine](https://github.com/quintel/etengine/pull/1735)
[model](https://github.com/quintel/etmodel/pull/4705)
[myetm](https://github.com/quintel/my-etm/pull/259)
[etlocal](https://github.com/quintel/etlocal/pull/680)
[projects](https://github.com/quintel/projects/pull/321)
[dbbot](https://github.com/quintel/dbbot/pull/9)


## Checklist
- [ ] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
