### PR TITLE
Rename gas plant full load hour keys

### DIFF
--- a/config/interface_elements/energy/energy_full_load_hours.yml
+++ b/config/interface_elements/energy/energy_full_load_hours.yml
@@ -2,7 +2,7 @@ key: energy_full_load_hours
 groups:
   - header: energy_fossil_full_load_hours
     items:
-      - key: energy_power_combined_cycle_network_gas_full_load_hours
+      - key: input_energy_power_combined_cycle_network_gas_full_load_hours
         unit: 'flh'
         combination_method:
           weighted_average:
@@ -12,7 +12,7 @@ groups:
         combination_method:
           weighted_average:
             - input_energy_power_ultra_supercritical_network_gas_production
-      - key: energy_power_turbine_network_gas_full_load_hours
+      - key: input_energy_power_turbine_network_gas_full_load_hours
         unit: 'flh'
         combination_method:
           weighted_average:

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -751,9 +751,9 @@ en:
         input_energy_chp_supercritical_waste_mix_full_load_hours: Waste mix CHP
         industry_chp_turbine_hydrogen_full_load_hours: Hydrogen turbine CHP - industry
         energy_power_supercritical_waste_mix_full_load_hours: Waste mix incinerator
-        energy_power_combined_cycle_network_gas_full_load_hours: Gas CCGT
+        input_energy_power_combined_cycle_network_gas_full_load_hours: Gas CCGT
         energy_power_ultra_supercritical_network_gas_full_load_hours: Gas conventional
-        energy_power_turbine_network_gas_full_load_hours: Gas turbine
+        input_energy_power_turbine_network_gas_full_load_hours: Gas turbine
         input_energy_chp_local_engine_network_gas_full_load_hours: Gas motor CHP (small-scale)
         input_energy_chp_combined_cycle_network_gas_full_load_hours: Gas CCGT CHP (large-scale)
         energy_power_supercritical_coal_full_load_hours: Coal conventional

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -764,7 +764,7 @@ nl:
         energy_power_supercritical_waste_mix_full_load_hours: Afvalverbrander
         energy_power_combined_cycle_network_gas_full_load_hours: Gas STEG
         energy_power_ultra_supercritical_network_gas_full_load_hours: Gas conventioneel
-        energy_power_turbine_network_gas_full_load_hours: Gasturbine
+        input_energy_power_turbine_network_gas_full_load_hours: Gasturbine
         input_energy_chp_local_engine_network_gas_full_load_hours: Gasmotor WKK (kleinschalig) met warmtelevering
         input_energy_chp_combined_cycle_network_gas_full_load_hours: Gas STEG WKK (grootschalig) met warmtelevering
         energy_power_supercritical_coal_full_load_hours: Kolen conventioneel

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -762,7 +762,7 @@ nl:
         input_energy_chp_supercritical_waste_mix_full_load_hours: Afvalverbrander met warmtelevering (WKK)
         industry_chp_turbine_hydrogen_full_load_hours: Waterstofturbine WKK - industrie
         energy_power_supercritical_waste_mix_full_load_hours: Afvalverbrander
-        energy_power_combined_cycle_network_gas_full_load_hours: Gas STEG
+        input_energy_power_combined_cycle_network_gas_full_load_hours: Gas STEG
         energy_power_ultra_supercritical_network_gas_full_load_hours: Gas conventioneel
         input_energy_power_turbine_network_gas_full_load_hours: Gasturbine
         input_energy_chp_local_engine_network_gas_full_load_hours: Gasmotor WKK (kleinschalig) met warmtelevering

--- a/db/migrate/20260423120959_rename_gas_full_load_hours_keys.rb
+++ b/db/migrate/20260423120959_rename_gas_full_load_hours_keys.rb
@@ -1,0 +1,21 @@
+class RenameGasFullLoadHoursKeys < ActiveRecord::Migration[7.0]
+
+  # old_key => new_key
+  KEYS = {
+    'energy_power_combined_cycle_network_gas_full_load_hours' => 'input_energy_power_combined_cycle_network_gas_full_load_hours',
+    'energy_power_turbine_network_gas_full_load_hours' => 'input_energy_power_turbine_network_gas_full_load_hours'
+  }.freeze
+
+  def self.up
+    dataset_edits = DatasetEdit.where(key: KEYS.keys)
+
+    KEYS.each do |old_key, new_key|
+      dataset_edits.where(key: old_key).in_batches { |batch| batch.update_all(key: new_key) }
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,67 +10,67 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_04_154120) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_23_120959) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "source_id"
-    t.integer "user_id"
-    t.text "message"
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.integer "dataset_id"
+    t.text "message"
+    t.integer "source_id"
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["dataset_id"], name: "index_commits_on_dataset_id"
     t.index ["source_id"], name: "index_commits_on_source_id"
     t.index ["user_id"], name: "index_commits_on_user_id"
   end
 
   create_table "dataset_edits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "commit_id"
-    t.string "key"
-    t.float "value", limit: 53
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "type"
     t.boolean "boolean_value"
+    t.integer "commit_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.string "key"
+    t.string "type"
+    t.datetime "updated_at", precision: nil, null: false
+    t.float "value", limit: 53
     t.index ["commit_id"], name: "index_dataset_edits_on_commit_id"
   end
 
   create_table "datasets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "user_id"
-    t.string "name", default: "", null: false
-    t.string "geo_id", default: "", null: false
-    t.string "data_source", default: "db", null: false
-    t.string "parent"
-    t.boolean "has_industry", default: false
-    t.boolean "has_agriculture", default: false
-    t.boolean "public", default: true
     t.datetime "created_at", precision: nil, null: false
+    t.string "data_source", default: "db", null: false
+    t.string "geo_id", default: "", null: false
+    t.boolean "has_agriculture", default: false
+    t.boolean "has_industry", default: false
+    t.string "name", default: "", null: false
+    t.string "parent"
+    t.boolean "public", default: true
     t.datetime "updated_at", precision: nil, null: false
+    t.integer "user_id"
     t.index ["user_id"], name: "index_datasets_on_user_id"
   end
 
   create_table "groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "key"
     t.datetime "created_at", precision: nil, null: false
+    t.string "key"
     t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "sources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.string "source_file_file_name"
     t.string "source_file_content_type"
+    t.string "source_file_file_name"
     t.integer "source_file_file_size"
     t.datetime "source_file_updated_at", precision: nil
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "group_id"
-    t.string "email", limit: 191, default: "", null: false
-    t.string "name"
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token", limit: 191
-    t.datetime "reset_password_sent_at", precision: nil
     t.datetime "created_at", precision: nil, null: false
+    t.string "email", limit: 191, default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.integer "group_id"
+    t.string "name"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "reset_password_token", limit: 191
     t.datetime "updated_at", precision: nil, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["group_id"], name: "index_users_on_group_id"


### PR DESCRIPTION
#### Context
Following the changes in [this PR](https://github.com/quintel/etsource/pull/3433), it was necessary to rename the full load hour ETLocal keys of gas power plants.

#### Implemented changes
- The prefix `input_` has been added to the ETLocal keys `energy_power_combined_cycle_network_gas_full_load_hours` and `energy_power_turbine_network_gas_full_load_hours`
- The SQGs on ETSource have been updated with the renamed keys. 
- A migration file is written to update the datasets with the renamed keys

At some point, the key names should be updated in the dataset pipeline. I will add the key name change in the file `Deferred work tracking.xlsx` on ETDataset while reviewing [this PR](https://github.com/quintel/etdataset/pull/1085).

#### Related

Closes issue #681 

Goes with pull request https://github.com/quintel/etsource/pull/3438

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review