### PR TITLE
Emissions add keys for ccus molecule nodes demand

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'config'
 gem 'git'
 
 gem 'transformer', ref: '2de0e46', github: 'quintel/transformer'
-gem 'atlas',       ref: 'f2e3f0d', github: 'quintel/atlas'
+gem 'atlas',       ref: 'fdbcda5', github: 'quintel/atlas'
 gem 'rubel',       ref: '9fe7010', github: 'quintel/rubel'
 gem 'refinery',    ref: '36b8e34', github: 'quintel/refinery'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'config'
 
 gem 'git'
 
-gem 'transformer', ref: '2de0e46', github: 'quintel/transformer'
-gem 'atlas',       ref: 'fdbcda5', github: 'quintel/atlas'
+gem 'transformer', ref: 'e88def3', github: 'quintel/transformer'
+gem 'atlas',       ref: 'db94f40', github: 'quintel/atlas'
 gem 'rubel',       ref: '9fe7010', github: 'quintel/rubel'
 gem 'refinery',    ref: '36b8e34', github: 'quintel/refinery'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: fdbcda5d54a0de369ba1b3397126cf012e38c0ed
-  ref: fdbcda5
+  revision: db94f40e616a0a8feddf21ceaa98117e267da025
+  ref: db94f40
   specs:
     atlas (1.0.0)
       activemodel (>= 7)
@@ -31,8 +31,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/transformer.git
-  revision: 2de0e46f845cfa8e91a3afd64852ea13104d1b17
-  ref: 2de0e46
+  revision: e88def3e830fdf438e094d8479f5edeacfe1781d
+  ref: e88def3
   specs:
     transformer (1.0.0)
       atlas (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f2e3f0de7a7fc9cd864fcf47ed3624c812803e83
-  ref: f2e3f0d
+  revision: fdbcda5d54a0de369ba1b3397126cf012e38c0ed
+  ref: fdbcda5
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/app/models/interface_item.rb
+++ b/app/models/interface_item.rb
@@ -7,7 +7,7 @@ class InterfaceItem
   validates_presence_of :unit, :key
   validates_inclusion_of :unit, in: %w[
     # kg kg/MJ km TJ % Mton km<sup>2</sup> € MW meter flh kWh/m<sup>2</sup>
-    string boolean m<sup>2</sup> kg-CO<sub>2</sub>
+    string boolean m<sup>2</sup> kgCO<sub>2</sub>
   ]
 
   attribute :key, Symbol

--- a/app/models/interface_item.rb
+++ b/app/models/interface_item.rb
@@ -5,7 +5,10 @@ class InterfaceItem
   include ActiveModel::Validations
 
   validates_presence_of :unit, :key
-  validates_inclusion_of :unit, in: %w[# kg kg/MJ km TJ % Mton km<sup>2</sup> € MW meter flh kWh/m<sup>2</sup> string boolean m<sup>2</sup>]
+  validates_inclusion_of :unit, in: %w[
+    # kg kg/MJ km TJ % Mton km<sup>2</sup> € MW meter flh kWh/m<sup>2</sup>
+    string boolean m<sup>2</sup> kg-CO<sub>2</sub>
+  ]
 
   attribute :key, Symbol
   attribute :unit, String

--- a/app/services/exporter.rb
+++ b/app/services/exporter.rb
@@ -23,7 +23,7 @@ module Exporter
       puts "Generating #{dataset['area']} with base set #{dataset['base_dataset']}"
       transformer = Transformer::DatasetGenerator.new(dataset)
 
-      transformer.preserve_paths(%w[curves]) do
+      transformer.preserve_paths(%w[curves emissions.csv]) do
         transformer.destroy if rebuild
         transformer.generate
       end

--- a/config/interface_elements/ccus/ccus.yml
+++ b/config/interface_elements/ccus/ccus.yml
@@ -1,0 +1,12 @@
+key: ccus
+groups:
+  - header: ccus_fertilizer_process_emissions
+    items:
+      - key: industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
+        unit: 'kg CO<sub>2</sub>'
+      - key: industry_chemicals_fertilizers_emitted_co2_demand
+        unit: 'kg CO<sub>2</sub>'
+  - header: ccus_utilisation
+    items:
+      - key: molecules_other_utilisation_co2_demand
+        unit: 'kg CO<sub>2</sub>'

--- a/config/interface_elements/ccus/ccus.yml
+++ b/config/interface_elements/ccus/ccus.yml
@@ -1,0 +1,1 @@
+key: ccus

--- a/config/interface_elements/ccus/ccus_default.yml
+++ b/config/interface_elements/ccus/ccus_default.yml
@@ -3,10 +3,10 @@ groups:
   - header: ccus_fertilizer_process_emissions
     items:
       - key: industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
-        unit: 'kg-CO<sub>2</sub'
+        unit: 'kgCO<sub>2</sub>'
       - key: industry_chemicals_fertilizers_emitted_co2_demand
-        unit: 'kg-CO<sub>2</sub>'
+        unit: 'kgCO<sub>2</sub>'
   - header: ccus_utilisation
     items:
-      - key: molecules_other_utilisation_delayed_emitted_co2
-        unit: 'kg-CO<sub>2</sub'
+      - key: molecules_other_utilisation_delayed_emitted_co2_demand
+        unit: 'kgCO<sub>2</sub>'

--- a/config/interface_elements/ccus/ccus_default.yml
+++ b/config/interface_elements/ccus/ccus_default.yml
@@ -8,5 +8,5 @@ groups:
         unit: 'kg-CO<sub>2</sub>'
   - header: ccus_utilisation
     items:
-      - key: molecules_other_utilisation_co2_demand
+      - key: molecules_other_utilisation_delayed_emitted_co2
         unit: 'kg-CO<sub>2</sub'

--- a/config/interface_elements/ccus/ccus_default.yml
+++ b/config/interface_elements/ccus/ccus_default.yml
@@ -1,12 +1,12 @@
-key: ccus
+key: ccus_default
 groups:
   - header: ccus_fertilizer_process_emissions
     items:
       - key: industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
-        unit: 'kg CO<sub>2</sub>'
+        unit: 'kg-CO<sub>2</sub'
       - key: industry_chemicals_fertilizers_emitted_co2_demand
-        unit: 'kg CO<sub>2</sub>'
+        unit: 'kg-CO<sub>2</sub>'
   - header: ccus_utilisation
     items:
       - key: molecules_other_utilisation_co2_demand
-        unit: 'kg CO<sub>2</sub>'
+        unit: 'kg-CO<sub>2</sub'

--- a/config/locales/descriptions_interface_items/en_ccus.yml
+++ b/config/locales/descriptions_interface_items/en_ccus.yml
@@ -6,6 +6,6 @@ en:
       industry_chemicals_fertilizers_emitted_co2_demand: |
         CO<sub>2</sub> that ends up to be emitted from fertilizer processes emissions (not captured
         in the end).
-      molecules_other_utilisation_delayed_emitted_co2: |
+      molecules_other_utilisation_delayed_emitted_co2_demand: |
         Other utilisation of CO<sub>2</sub> which is emitted to the atmosphere in the
         short term.

--- a/config/locales/descriptions_interface_items/en_ccus.yml
+++ b/config/locales/descriptions_interface_items/en_ccus.yml
@@ -1,0 +1,11 @@
+en:
+  descriptions:
+    interface_items:
+      industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: |
+        Potential CO<sub>2</sub> from fertilizer process emissions that is available for capture.
+      industry_chemicals_fertilizers_emitted_co2_demand: |
+        CO<sub>2</sub> that ends up to be emitted from fertilizer processes emissions (not captured
+        in the end).
+      molecules_other_utilisation_co2_demand: |
+        Other utilisation of CO<sub>2</sub> that could again be released to the atmosphere in the
+        short term or could be utilised indefinitely.

--- a/config/locales/descriptions_interface_items/en_ccus.yml
+++ b/config/locales/descriptions_interface_items/en_ccus.yml
@@ -6,6 +6,6 @@ en:
       industry_chemicals_fertilizers_emitted_co2_demand: |
         CO<sub>2</sub> that ends up to be emitted from fertilizer processes emissions (not captured
         in the end).
-      molecules_other_utilisation_co2_demand: |
-        Other utilisation of CO<sub>2</sub> that could again be released to the atmosphere in the
-        short term or could be utilised indefinitely.
+      molecules_other_utilisation_delayed_emitted_co2: |
+        Other utilisation of CO<sub>2</sub> which is emitted to the atmosphere in the
+        short term.

--- a/config/locales/descriptions_interface_items/en_ccus.yml
+++ b/config/locales/descriptions_interface_items/en_ccus.yml
@@ -4,8 +4,6 @@ en:
       industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: |
         Potential CO<sub>2</sub> from fertilizer process emissions that is available for capture.
       industry_chemicals_fertilizers_emitted_co2_demand: |
-        CO<sub>2</sub> that ends up to be emitted from fertilizer processes emissions (not captured
-        in the end).
+        CO<sub>2</sub> that ends up to be emitted from fertilizer processes emissions (potential that is not captured).
       molecules_other_utilisation_delayed_emitted_co2_demand: |
-        Other utilisation of CO<sub>2</sub> which is emitted to the atmosphere in the
-        short term.
+        Other utilisation of CO<sub>2</sub> which is emitted to the atmosphere in the short term.

--- a/config/locales/descriptions_interface_items/nl_ccus.yml
+++ b/config/locales/descriptions_interface_items/nl_ccus.yml
@@ -7,6 +7,5 @@ nl:
       industry_chemicals_fertilizers_emitted_co2_demand: |
         De CO<sub>2</sub> van procesemissies van de kunstmestsector die uiteindelijk wordt
         uitgestoten (en niet afgevangen).
-      molecules_other_utilisation_co2_demand: |
-        Overig gebruik van CO<sub>2</sub> dat op korte termijn weer kan vrijkomen in de atmosfeer
-        of voor onbepaalde tijd kan worden benut.
+      molecules_other_utilisation_delayed_emitted_co2: |
+        Overig gebruik van CO<sub>2</sub> dat op korte termijn weer wordt uitgestoten.

--- a/config/locales/descriptions_interface_items/nl_ccus.yml
+++ b/config/locales/descriptions_interface_items/nl_ccus.yml
@@ -7,5 +7,5 @@ nl:
       industry_chemicals_fertilizers_emitted_co2_demand: |
         De CO<sub>2</sub> van procesemissies van de kunstmestsector die uiteindelijk wordt
         uitgestoten (en niet afgevangen).
-      molecules_other_utilisation_delayed_emitted_co2: |
+      molecules_other_utilisation_delayed_emitted_co2_demand: |
         Overig gebruik van CO<sub>2</sub> dat op korte termijn weer wordt uitgestoten.

--- a/config/locales/descriptions_interface_items/nl_ccus.yml
+++ b/config/locales/descriptions_interface_items/nl_ccus.yml
@@ -1,0 +1,12 @@
+nl:
+  descriptions:
+    interface_items:
+      industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: |
+        Potentiële CO<sub>2</sub> uit procesemissies van de kunstmestsector die beschikbaar is voor
+        afvang.
+      industry_chemicals_fertilizers_emitted_co2_demand: |
+        De CO<sub>2</sub> van procesemissies van de kunstmestsector die uiteindelijk wordt
+        uitgestoten (en niet afgevangen).
+      molecules_other_utilisation_co2_demand: |
+        Overig gebruik van CO<sub>2</sub> dat op korte termijn weer kan vrijkomen in de atmosfeer
+        of voor onbepaalde tijd kan worden benut.

--- a/config/locales/descriptions_interface_items/nl_ccus.yml
+++ b/config/locales/descriptions_interface_items/nl_ccus.yml
@@ -6,6 +6,6 @@ nl:
         afvang.
       industry_chemicals_fertilizers_emitted_co2_demand: |
         De CO<sub>2</sub> van procesemissies van de kunstmestsector die uiteindelijk wordt
-        uitgestoten (en niet afgevangen).
+        uitgestoten (het potentieel dat niet is afgevangen).
       molecules_other_utilisation_delayed_emitted_co2_demand: |
         Overig gebruik van CO<sub>2</sub> dat op korte termijn weer wordt uitgestoten.

--- a/config/locales/en_descriptions.yml
+++ b/config/locales/en_descriptions.yml
@@ -148,6 +148,8 @@ en:
         Energy Transition Model</a>.
       energy_biomass: |
         In this tab you will find information about green gas, waste and the potential of biomass.
+      ccus: |
+        This section gives information about CO<sub>2</sub> capture and utilisation.
       ccus_default: |
         This tab provides data for CO<sub>2</sub> capture and utilisation.
       curves: |

--- a/config/locales/en_descriptions.yml
+++ b/config/locales/en_descriptions.yml
@@ -149,7 +149,7 @@ en:
       energy_biomass: |
         In this tab you will find information about green gas, waste and the potential of biomass.
       ccus_default: |
-        Text ccus
+        This tab provides data for CO<sub>2</sub> capture and utilisation.
       curves: |
         The ETM calculates supply and demand of gas, electricity, heat and hydrogen on an hourly basis. Hourly profiles are required for this
         calculation and can be found in this section. Often the same profiles are used for a region within a country as the country itself.

--- a/config/locales/en_descriptions.yml
+++ b/config/locales/en_descriptions.yml
@@ -148,6 +148,8 @@ en:
         Energy Transition Model</a>.
       energy_biomass: |
         In this tab you will find information about green gas, waste and the potential of biomass.
+      ccus_default: |
+        Text ccus
       curves: |
         The ETM calculates supply and demand of gas, electricity, heat and hydrogen on an hourly basis. Hourly profiles are required for this
         calculation and can be found in this section. Often the same profiles are used for a region within a country as the country itself.

--- a/config/locales/en_headers.yml
+++ b/config/locales/en_headers.yml
@@ -195,6 +195,10 @@ en:
       energy_renewable_full_load_hours_max: Maximum full load hours of renewable power plants
       energy_distribution_losses: Distribution losses
 
+      # CCUS
+      ccus_fertilizer_process_emissions: Fertilizer sector process emissions
+      ccus_utilisation: Utilisation of CO<sub>2</sub>
+
       # curves
       curves_supply_electricity: Supply - Electricity
       curves_supply_heat: Supply - Heat

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -881,7 +881,7 @@ en:
         # CCUS
         industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potential CO2 for capture
         industry_chemicals_fertilizers_emitted_co2_demand: Emitted CO2
-        molecules_other_utilisation_delayed_emitted_co2: Other utilisation - delayed emitted
+        molecules_other_utilisation_delayed_emitted_co2_demand: Other utilisation - delayed emitted
 
   activerecord:
     attributes:

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -869,11 +869,6 @@ en:
         input_agriculture_chp_wood_pellets_steam_hot_water_output_conversion: Biomass CHP (agriculture) - heat efficiency
         input_agriculture_chp_engine_biogas_steam_hot_water_output_conversion: Biogas CHP (agriculture) - heat efficiency
 
-        # CCUS
-        industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: final
-        industry_chemicals_fertilizers_emitted_co2_demand: emitted
-        molecules_other_utilisation_co2_demand: other ut
-
         #Other
         other_final_demand_electricity_demand: Electricity
         other_final_demand_network_gas_demand: Gas
@@ -886,7 +881,7 @@ en:
         # CCUS
         industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potential CO2 for capture
         industry_chemicals_fertilizers_emitted_co2_demand: Emitted CO2
-        molecules_other_utilisation_co2_demand: Other utilisation
+        molecules_other_utilisation_delayed_emitted_co2: Other utilisation - delayed emitted
 
   activerecord:
     attributes:

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -869,6 +869,11 @@ en:
         input_agriculture_chp_wood_pellets_steam_hot_water_output_conversion: Biomass CHP (agriculture) - heat efficiency
         input_agriculture_chp_engine_biogas_steam_hot_water_output_conversion: Biogas CHP (agriculture) - heat efficiency
 
+        # CCUS
+        industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: final
+        industry_chemicals_fertilizers_emitted_co2_demand: emitted
+        molecules_other_utilisation_co2_demand: other ut
+
         #Other
         other_final_demand_electricity_demand: Electricity
         other_final_demand_network_gas_demand: Gas

--- a/config/locales/en_interface_elements.yml
+++ b/config/locales/en_interface_elements.yml
@@ -878,6 +878,11 @@ en:
         other_final_demand_crude_oil_demand: Oil
         other_final_demand_crude_oil_non_energetic_demand: Oil (non-energetic)
 
+        # CCUS
+        industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potential CO2 for capture
+        industry_chemicals_fertilizers_emitted_co2_demand: Emitted CO2
+        molecules_other_utilisation_co2_demand: Other utilisation
+
   activerecord:
     attributes:
       dataset_edit:

--- a/config/locales/en_sidebar_items.yml
+++ b/config/locales/en_sidebar_items.yml
@@ -75,6 +75,9 @@ en:
         curves_default: Default curves
         curves_weather_years: Weather year curves
 
+      ccus:
+        ccus_default: CCUS
+
       energy:
         energy_energy_demand: Energy demand
         energy_heat_production: District heating sources

--- a/config/locales/en_sidebar_items.yml
+++ b/config/locales/en_sidebar_items.yml
@@ -51,6 +51,7 @@ en:
       other: Other energy demand
       energy: Energy production
       transport: Transport
+      ccus: CCUS
       curves: Hourly curves
 
     subgroups:

--- a/config/locales/nl_descriptions.yml
+++ b/config/locales/nl_descriptions.yml
@@ -151,7 +151,7 @@ nl:
       energy_biomass: |
         In dit tabblad vind je informatie over groen gas, afval en de potentie van biomassa.
       ccus_default: |
-        Text ccus
+        Dit tabblad geeft informatie over afvang en gebruik van CO<sub>2</sub>.
       curves: |
         Het ETM rekent vraag en aanbod van gas, elekriciteit, warmte en waterstof uit op uurbasis. Voor deze berekening zijn uurprofielen nodig
         en deze kan je vinden in deze sectie. Vaak wordt voor een regio binnen een land dezelfde profielen gebruikt als het land zelf.

--- a/config/locales/nl_descriptions.yml
+++ b/config/locales/nl_descriptions.yml
@@ -150,6 +150,8 @@ nl:
         Energietransitiemodel</a>.
       energy_biomass: |
         In dit tabblad vind je informatie over groen gas, afval en de potentie van biomassa.
+      ccus_default: |
+        Text ccus
       curves: |
         Het ETM rekent vraag en aanbod van gas, elekriciteit, warmte en waterstof uit op uurbasis. Voor deze berekening zijn uurprofielen nodig
         en deze kan je vinden in deze sectie. Vaak wordt voor een regio binnen een land dezelfde profielen gebruikt als het land zelf.

--- a/config/locales/nl_descriptions.yml
+++ b/config/locales/nl_descriptions.yml
@@ -150,6 +150,8 @@ nl:
         Energietransitiemodel</a>.
       energy_biomass: |
         In dit tabblad vind je informatie over groen gas, afval en de potentie van biomassa.
+      ccus: |
+        Deze sectie geeft informatie over afvang en gebruik van CO<sub>2</sub>.
       ccus_default: |
         Dit tabblad geeft informatie over afvang en gebruik van CO<sub>2</sub>.
       curves: |

--- a/config/locales/nl_headers.yml
+++ b/config/locales/nl_headers.yml
@@ -197,6 +197,10 @@ nl:
       energy_renewable_full_load_hours_max: Maximum vollasturen van hernieuwbare centrales
       energy_distribution_losses: Distributieverliezen
 
+      # CCUS
+      ccus_fertilizer_process_emissions: Kunstmestsector procesemissies
+      ccus_utilisation: Gebruik van CO<sub>2</sub>
+
       # curves
       curves_supply_electricity: Aanbod - Elektriciteit
       curves_supply_heat: Aanbod - Warmte

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -883,7 +883,7 @@ nl:
         # CCUS
         industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potentiële CO2 voor afvang
         industry_chemicals_fertilizers_emitted_co2_demand: Uitgestoten CO2
-        molecules_other_utilisation_co2_demand: Overig gebruik
+        molecules_other_utilisation_delayed_emitted_co2: Overig gebruik - uitgestelde uitstoot
 
         #Other
         other_final_demand_electricity_demand: Elektriciteit

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -880,6 +880,11 @@ nl:
         input_agriculture_chp_engine_biogas_steam_hot_water_output_conversion: Biogas WKK (landbouw) - efficiêntie warmte
         input_agriculture_chp_wood_pellets_steam_hot_water_output_conversion: Biomassa WKK (landbouw) - efficiêntie warmte
 
+        # CCUS
+        industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potentiële CO2 voor afvang
+        industry_chemicals_fertilizers_emitted_co2_demand: Uitgestoten CO2
+        molecules_other_utilisation_co2_demand: Overig gebruik
+
         #Other
         other_final_demand_electricity_demand: Elektriciteit
         input_other_final_demand_network_gas_demand: Gas

--- a/config/locales/nl_interface_elements.yml
+++ b/config/locales/nl_interface_elements.yml
@@ -883,7 +883,7 @@ nl:
         # CCUS
         industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand: Potentiële CO2 voor afvang
         industry_chemicals_fertilizers_emitted_co2_demand: Uitgestoten CO2
-        molecules_other_utilisation_delayed_emitted_co2: Overig gebruik - uitgestelde uitstoot
+        molecules_other_utilisation_delayed_emitted_co2_demand: Overig gebruik - uitgestelde uitstoot
 
         #Other
         other_final_demand_electricity_demand: Elektriciteit

--- a/config/locales/nl_sidebar_items.yml
+++ b/config/locales/nl_sidebar_items.yml
@@ -51,6 +51,7 @@ nl:
       energy: Energieproductie
       transport: Transport
       other: Overige vraag
+      ccus: CCUS
       curves: Uurprofielen
 
     subgroups:

--- a/config/locales/nl_sidebar_items.yml
+++ b/config/locales/nl_sidebar_items.yml
@@ -75,6 +75,9 @@ nl:
         curves_default: Standaardprofielen
         curves_weather_years: Weerjaarprofielen
 
+      ccus:
+        ccus_default: CCUS
+
       energy:
         energy_energy_demand: Energievraag
         energy_heat_production: Bronnen warmtenet

--- a/config/menu.yml
+++ b/config/menu.yml
@@ -44,8 +44,7 @@ energy:
   - energy_efficiency
   - energy_biomass
   - energy_fuel_production
-
+ccus:
 curves:
   - curves_default
   - curves_weather_years
-

--- a/config/menu.yml
+++ b/config/menu.yml
@@ -45,6 +45,7 @@ energy:
   - energy_biomass
   - energy_fuel_production
 ccus:
+  - ccus_default
 curves:
   - curves_default
   - curves_weather_years

--- a/db/migrate/20260617131449_emission_keys_all_datasets.rb
+++ b/db/migrate/20260617131449_emission_keys_all_datasets.rb
@@ -1,0 +1,57 @@
+class EmissionKeysAllDatasets < ActiveRecord::Migration[8.1]
+  EMISSION_KEYS = %w[
+    industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
+    industry_chemicals_fertilizers_emitted_co2_demand
+    molecules_other_utilisation_co2_demand
+  ].freeze
+
+  def up
+    Dataset.find_each do |dataset|
+      ActiveRecord::Base.transaction do
+        commit = Commit.create!(
+          user: User.robot,
+          dataset_id: dataset.id,
+          message: 'Dynamic emission calculation, defaults to zero'
+        )
+
+        EMISSION_KEYS.each do |key|
+          DatasetEdit.create!(
+            commit_id: commit.id,
+            key: key,
+            value: 0.0
+          )
+        end
+      end
+    end
+  end
+
+  def down
+    Dataset.find_each do |dataset|
+      EMISSION_KEYS.each { |edit_key| destroy_edits(dataset, edit_key) }
+    end
+  end
+
+  # Removes all dataset edits matching the `edit_key`. If the key is the only
+  # dataset belonging to the commit, the commit will also be removed.
+  def destroy_edits(dataset, edit_key)
+    commits = find_commits(dataset, edit_key)
+
+    return if commits.none?
+
+    commits.each do |commit|
+      if commit.dataset_edits.one?
+        commit.destroy
+      else
+        commit.dataset_edits.find_by(key: edit_key).destroy
+      end
+    end
+  end
+
+  # Finds all commits belonging to a dataset with an edit to the given key.
+  def find_commits(dataset, edit_key)
+    dataset.commits
+           .joins(:dataset_edits)
+           .where(dataset_edits: { key: edit_key })
+           .order(updated_at: :desc)
+  end
+end

--- a/db/migrate/20260617131449_emission_keys_all_datasets.rb
+++ b/db/migrate/20260617131449_emission_keys_all_datasets.rb
@@ -2,7 +2,7 @@ class EmissionKeysAllDatasets < ActiveRecord::Migration[8.1]
   EMISSION_KEYS = %w[
     industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
     industry_chemicals_fertilizers_emitted_co2_demand
-    molecules_other_utilisation_co2_demand
+    molecules_other_utilisation_delayed_emitted_co2
   ].freeze
 
   def up

--- a/db/migrate/20260617131449_emission_keys_all_datasets.rb
+++ b/db/migrate/20260617131449_emission_keys_all_datasets.rb
@@ -2,7 +2,7 @@ class EmissionKeysAllDatasets < ActiveRecord::Migration[8.1]
   EMISSION_KEYS = %w[
     industry_final_demand_for_chemical_fertilizers_network_gas_non_energetic_co2_demand
     industry_chemicals_fertilizers_emitted_co2_demand
-    molecules_other_utilisation_delayed_emitted_co2
+    molecules_other_utilisation_delayed_emitted_co2_demand
   ].freeze
 
   def up

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_120959) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_131449) do
   create_table "commits", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.integer "dataset_id"


### PR DESCRIPTION
#### Context
For the emissions project, three ETLocal keys for demand of ccus molecule nodes have been added to ensure that scenario results remain the same.

#### Implemented changes
- Three new ETLocal keys added
- New CCUS section added in the interface

#### Related

Goes with pull requests:
- https://github.com/quintel/atlas/pull/193
- https://github.com/quintel/transformer/pull/22
- https://github.com/quintel/etsource/pull/3448
- https://github.com/quintel/etlocal/pull/694

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
