### PR TITLE
Emissions no zeroing of preset value for derived datasets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'config'
 
 gem 'git'
 
-gem 'transformer', ref: 'e88def3', github: 'quintel/transformer'
-gem 'atlas',       ref: 'db94f40', github: 'quintel/atlas'
+gem 'transformer', ref: '90ce36b', github: 'quintel/transformer'
+gem 'atlas',       ref: '21a6046', github: 'quintel/atlas'
 gem 'rubel',       ref: '9fe7010', github: 'quintel/rubel'
 gem 'refinery',    ref: '36b8e34', github: 'quintel/refinery'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'config'
 
 gem 'git'
 
-gem 'transformer', ref: '2de0e46', github: 'quintel/transformer'
-gem 'atlas',       ref: 'f2e3f0d', github: 'quintel/atlas'
+gem 'transformer', ref: 'e88def3', github: 'quintel/transformer'
+gem 'atlas',       ref: 'db94f40', github: 'quintel/atlas'
 gem 'rubel',       ref: '9fe7010', github: 'quintel/rubel'
 gem 'refinery',    ref: '36b8e34', github: 'quintel/refinery'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: db94f40e616a0a8feddf21ceaa98117e267da025
-  ref: db94f40
+  revision: 21a60468b711e700ec2964a4f3c9c942f5ba3c7b
+  ref: 21a6046
   specs:
     atlas (1.0.0)
       activemodel (>= 7)
@@ -31,8 +31,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/transformer.git
-  revision: e88def3e830fdf438e094d8479f5edeacfe1781d
-  ref: e88def3
+  revision: 90ce36b5aa1bb9b74180c92246bf493cd82b9953
+  ref: 90ce36b
   specs:
     transformer (1.0.0)
       atlas (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f2e3f0de7a7fc9cd864fcf47ed3624c812803e83
-  ref: f2e3f0d
+  revision: db94f40e616a0a8feddf21ceaa98117e267da025
+  ref: db94f40
   specs:
     atlas (1.0.0)
       activemodel (>= 7)
@@ -31,8 +31,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/transformer.git
-  revision: 2de0e46f845cfa8e91a3afd64852ea13104d1b17
-  ref: 2de0e46
+  revision: e88def3e830fdf438e094d8479f5edeacfe1781d
+  ref: e88def3
   specs:
     transformer (1.0.0)
       atlas (~> 1.0)

--- a/app/services/exporter.rb
+++ b/app/services/exporter.rb
@@ -23,7 +23,7 @@ module Exporter
       puts "Generating #{dataset['area']} with base set #{dataset['base_dataset']}"
       transformer = Transformer::DatasetGenerator.new(dataset)
 
-      transformer.preserve_paths(%w[curves]) do
+      transformer.preserve_paths(%w[curves emissions.csv]) do
         transformer.destroy if rebuild
         transformer.generate
       end


### PR DESCRIPTION
#### Implemented changes
Avoid removing emissions.csv files when exporting datasets from ETLocal to ETSource. 

#### Related

Goes with pull requests:
- https://github.com/quintel/atlas/pull/193
- https://github.com/quintel/transformer/pull/22
- https://github.com/quintel/etsource/pull/3448

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
